### PR TITLE
Nix: initialise nix flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,4 @@
+if ! has nix_direnv_version || ! nix_direnv_version 2.3.0; then
+    source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/2.3.0/direnvrc" "sha256-Dmd+j63L84wuzgyjITIfSxSD57Tx7v51DMxVZOsiUD8="
+fi
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .Ruserdata
 data
 data.zip
+.direnv

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+
+data:
+	R -e "rmarkdown::render('plantbreedgame_setup.Rmd')"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ But if you want to install the game on your own computer or server, read on!
 
 # Installation
 
+> Note: for nix users, a flake is available in this repository (cf. [Nix](#Nix-snowflake) section)
+
 ## Dependencies
 
 Before using this game, you need to install R as well as various packages, listed in the file [`src/dependencies.R`](https://github.com/timflutre/PlantBreedGame/blob/master/src/dependencies.R).
@@ -45,11 +47,16 @@ The package can also be installed after cloning the git repository:
 git clone git@github.com:timflutre/PlantBreedGame.git
 ```
 
-2. Then, enter into the `PlantBreedGame` directory; inside, run the script `plantbreedgame_setup.Rmd` using [Rmarkdown](http://rmarkdown.rstudio.com/) to simulate the initial data set, for example with the command:
+2. Then, enter into the `PlantBreedGame` directory; inside, run the script `plantbreedgame_setup.Rmd` using [Rmarkdown](http://rmarkdown.rstudio.com/) to simulate the initial data set, this can be done with the command:
 
 ```sh
-R -e "rmarkdown::render('plantbreedgame_setup.Rmd')"
+make data
 ```
+
+> Or with R:
+>  ```sh
+>  R -e "rmarkdown::render('plantbreedgame_setup.Rmd')"
+>  ```
 
  It also creates all the necessary files and database for the game to function, and initiate the game with two players, "test" (no password) and "admin" (password `1234`).
 
@@ -241,6 +248,19 @@ This tab also allows a game master to create new breeders and sessions, among ot
 
 You can modify some key parameters of the game, e.g., effective population size, heritabilities, genetic correlation.
 For this, you need to edit the setup file [`plantbreedgame_setup.Rmd`](https://github.com/timflutre/PlantBreedGame/blob/master/plantbreedgame_setup.Rmd), notably by changing the parameters' values in the sections `Simulate haplotypes and genotypes` and `Simulate phenotypes` (e.g., subsection `Simulation procedure for trait 1`).
+
+
+# Nix :snowflake: 
+
+This repository uses a "[nix](https://nixos.org/) flake" and [`direnv`](https://direnv.net/). If you have nix and direnv installed just `cd` in this repo, enable direnv (`direnv allow`) and all dependencies will be automatically installed and available in a dedicated environment.
+
+You can then launch the application with:
+
+```sh
+nix run
+```
+
+To install nix you can visit: https://github.com/DeterminateSystems/nix-installer
 
 # Citation
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,60 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1710695816,
+        "narHash": "sha256-3Eh7fhEID17pv9ZxrPwCLfqXnYP006RKzSs0JptsN84=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "614b4613980a522ba49f0d194531beddbb7220d3",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-23.11",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,89 @@
+{
+  description = "Flake for a R environment";
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-23.11";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+  }:
+    flake-utils.lib.eachDefaultSystem (system:
+        let
+          pkgs = import nixpkgs {inherit system;};
+          Rpkgs = pkgs;
+          R-with-my-packages = Rpkgs.rWrapper.override {
+            packages = with Rpkgs.rPackages; [
+              shiny
+              shinydashboard
+              shinycssloaders
+              shinyjs
+              RSQLite
+              MASS
+              digest
+              plotly
+              DT
+              igraph
+              lubridate
+              vistime
+              scrm
+              GenomicRanges
+
+              (pkgs.rPackages.buildRPackage {
+                name = "rutilstimflutre";
+                src = pkgs.fetchFromGitHub {
+                  owner = "timflutre";
+                  repo = "rutilstimflutre";
+                  rev = "42660be440687c50169acae592cc32e1a11e4255";
+                  sha256 = "sha256-Au1Izpuht83S4oEhq+1fq4cIrOt+48DbsCoxNvdndi4=";
+                };
+                propagatedBuildInputs = with pkgs.rPackages; [data_table lme4 Matrix Rcpp];
+              })
+
+
+            ];
+          };
+        in {
+
+          devShells.default =
+            pkgs.mkShell {
+              LOCALE_ARCHIVE = if "${system}" == "x86_64-linux" then "${pkgs.glibcLocalesUtf8}/lib/locale/locale-archive" else "";
+              R_LIBS_USER = "''"; # to not use users' installed R packages
+              R_ZIPCMD = "${pkgs.zip}/bin/zip";
+              nativeBuildInputs = [pkgs.bashInteractive];
+              buildInputs = [
+                R-with-my-packages
+                pkgs.zip
+              ];
+            };
+
+          apps = {
+            default = let
+              PlantBreedGame = pkgs.writeShellApplication {
+                name = "PlantBreedGame";
+                text = ''
+                  Rscript --vanilla -e "shiny::runApp()"
+                '';
+              };
+            in {
+              type = "app";
+              program = "${PlantBreedGame}/bin/PlantBreedGame";
+            };
+            initialise-data = let
+              initialise-data = pkgs.writeShellApplication {
+                name = "initialise-data";
+                text = ''
+                  make data
+                '';
+              };
+            in {
+              type = "app";
+              program = "${initialise-data}/bin/initialise-data";
+            };
+          };
+        }
+        );
+}
+


### PR DESCRIPTION
I add a "nix flake" to the repo (+ a small refactor on how to generate the `data` folder using `make`).

@timflutre, I don't know if you know about "nix", but if you don't, this will have no effects for non-nix users, but for those who do it ease the installation process as it generate an independent environment with **all** the dependencies (ie. the R packages, R itself, `zip` etc...) pined to a particular version.

(By the way, if you don't know about nix, I highly suggest you to have a look you will probably like it).
