### PR TITLE
add `vcf.gz` genotype download

### DIFF
--- a/src/dependencies.R
+++ b/src/dependencies.R
@@ -33,6 +33,7 @@ library(DT)
 library(igraph)
 library(lubridate)
 library(vistime)
+library(tidyr)
 
 ## required packages NOT available on the CRAN
 ## R> devtools::install_github("timflutre/rutilstimflutre")

--- a/src/ui_id_loggedIn.R
+++ b/src/ui_id_loggedIn.R
@@ -35,7 +35,7 @@ shinydashboard::tabBox(width=12, title =paste0("My account"),
                 ),
                 div(
                     h3("Genotyping data:"),
-                    selectInput("genoFile", "", choices=genoFiles(),width="75%"),
+                    selectInput("genoFile", "", choices = genoFiles(), width="75%"),
                     uiOutput("UIdwnlGeno")
                 )
             ),


### PR DESCRIPTION
This feature allow users to download the genetic data in a "vcf" format.
It can be helpful if users want to import those data in external genetic tools. 

However, VCF format request some information that we do not simulate (eg. REF / ALT), for those I use `.`.  

For example: 
 
```
##fileformat=VCFv4.3
##source="PlantBreedGame", data in this file are simulated.
##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	Coll0301	Coll0302
chr1	878	snp00007	.	.	.	PASS	.	GT	1/1	1/1	1/1	
chr1	1215	snp00009	.	.	.	PASS	.	GT	1/1	1/1	
chr1	3392	snp00020	.	.	.	PASS	.	GT	1/1	1/1	
chr1	6821	snp00029	.	.	.	PASS	.	GT	1/1	1/1	
chr1	8322	snp00032	.	.	.	PASS	.	GT	1/1	1/1	
```