### PR TITLE
Add some game initialisation parameters

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,3 +29,13 @@ jobs:
         path: playwright-report/
         retention-days: 30
 
+
+  initialise_data_from_script:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: cachix/install-nix-action@v25
+      with:
+        github_access_token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: DeterminateSystems/magic-nix-cache-action@v2
+    - run: nix develop -c -- nix run .\#initialise-data

--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,7 @@
           vistime
           scrm
           GenomicRanges
+          bsicons
 
           (pkgs.rPackages.buildRPackage {
             name = "rutilstimflutre";

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,7 @@
           shinydashboard
           shinycssloaders
           shinyjs
+          shinyvalidate
           RSQLite
           MASS
           digest

--- a/global.R
+++ b/global.R
@@ -27,6 +27,8 @@ source("src/fun/func_id.R", local = TRUE, encoding = "UTF-8")
 source("./src/fun/module_constants.R", local = TRUE, encoding = "UTF-8")
 source("./src/fun/module_breederList.R", local = TRUE, encoding = "UTF-8")
 source("./src/fun/func_dbRequests.R", local = TRUE, encoding = "UTF-8")
+source("./src/fun/module_gameInit_params.R", local = TRUE, encoding = "UTF-8")
+source("./src/fun/func_gameInit_validation.R", local = TRUE, encoding = "UTF-8")
 
 ## -------------------------------------------------------------------
 ## parameters

--- a/initialise_data.R
+++ b/initialise_data.R
@@ -1,8 +1,25 @@
 #! /usr/bin/env Rscript
 
+params = list(
+  rng_seed = 1993,
+  cost.pheno.field = 50,
+  cost.pheno.patho = 0.1,
+  cost.allof = 0.1,
+  cost.autof = 0.25,
+  cost.haplodiplo = 1,
+  cost.geno.hd = 1,
+  cost.geno.ld = 0.5,
+  cost.geno.single = 0.02,
+  cost.register = 4,
+  initialBudget = 3900
+)
+
+
 out_report <- rmarkdown::render("./src/plantbreedgame_setup.Rmd",
   output_file = tempfile(),
-  encoding = "UTF-8"
+  encoding = "UTF-8",
+  params = params,
+  envir = new.env(parent = globalenv()),
 )
 file.copy(
   from = out_report,

--- a/initialise_data.R
+++ b/initialise_data.R
@@ -2,6 +2,7 @@
 
 params = list(
   rng_seed = 1993,
+
   cost.pheno.field = 50,
   cost.pheno.patho = 0.1,
   cost.allof = 0.1,
@@ -11,7 +12,20 @@ params = list(
   cost.geno.ld = 0.5,
   cost.geno.single = 0.02,
   cost.register = 4,
-  initialBudget = 3900
+  initialBudget = 3900,
+
+  t1_mu = 100,
+  t1_min = 20,
+  t1_cv_g = 0.1,
+  t1_h2 = 0.3,
+
+  t2_mu = 15,
+  t2_min = 5,
+  t2_cv_g = 0.06,
+  t2_h2 = 0.6,
+
+  prop_pleio = 0.4,
+  cor_pleio = -0.7
 )
 
 

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -73,8 +73,7 @@ module.exports = defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    // command: "rm -r data; unzip data.zip -d .; nix run",
-    command: "nix run",
+    command: "rm -rf data/*; rm  data.zip; nix run",
     url: "http://127.0.0.1:3000",
     reuseExistingServer: true,
   },

--- a/src/dependencies.R
+++ b/src/dependencies.R
@@ -27,6 +27,7 @@ suppressPackageStartupMessages({
   library(shinydashboard)
   library(shinycssloaders)
   library(shinyjs)
+  library(shinyvalidate)
   library(RSQLite)
   library(MASS)
   library(digest)

--- a/src/dependencies.R
+++ b/src/dependencies.R
@@ -37,6 +37,7 @@ suppressPackageStartupMessages({
   library(lubridate)
   library(vistime)
   library(tidyr)
+  library(bsicons)
 
   ## required packages NOT available on the CRAN
   ## R> devtools::install_github("timflutre/rutilstimflutre")

--- a/src/fun/func_gameInit_validation.R
+++ b/src/fun/func_gameInit_validation.R
@@ -100,12 +100,36 @@ valid_number <- function(x, accept_null = TRUE, raise_error = FALSE) {
     error("Mandatory and should be a number")
   }
 
+  if (!is.numeric(x)) {
+    error("Mandatory and should be a number")
+  }
+
   return(NULL)
 }
 
 valid_range <- function(x, min, max, incl_min = TRUE, incl_max = TRUE, accept_null = TRUE, raise_error = FALSE) {
 
   error <- return
+  error <- return
+  if (raise_error) {
+    error <- stop
+  }
+  error <- return
+  if (raise_error) {
+    error <- stop
+  }
+  error <- return
+  if (raise_error) {
+    error <- stop
+  }
+  error <- return
+  if (raise_error) {
+    error <- stop
+  }
+  error <- return
+  if (raise_error) {
+    error <- stop
+  }
   if (raise_error) {
     error <- stop
   }
@@ -118,6 +142,10 @@ valid_range <- function(x, min, max, incl_min = TRUE, incl_max = TRUE, accept_nu
   }
 
   if (is.na(x)) {
+    error("Mandatory and should be a number")
+  }
+
+  if (!is.numeric(x)) {
     error("Mandatory and should be a number")
   }
 
@@ -151,7 +179,31 @@ valid_range <- function(x, min, max, incl_min = TRUE, incl_max = TRUE, accept_nu
 }
 
 valid_mu <- function(x, accept_null = TRUE, raise_error = FALSE) {
-  valid_number(x, accept_null, raise_error)
+  error <- return
+  if (raise_error) {
+    error <- stop
+  }
+
+  if (is.null(x)) {
+    if (accept_null) {
+      return(NULL)
+    }
+    error("Must not be NULL")
+  }
+
+  if (is.na(x)) {
+    error("Mandatory and should be a number")
+  }
+
+  if (!is.numeric(x)) {
+    error("Mandatory and should be a number")
+  }
+
+  if (x == 0) {
+    error("μ cannot be null")
+  }
+
+  return(NULL)
 }
 
 valid_Tmin <- function(x, mu, accept_null = TRUE, raise_error = FALSE) {
@@ -168,6 +220,10 @@ valid_Tmin <- function(x, mu, accept_null = TRUE, raise_error = FALSE) {
   }
 
   if (is.na(x)) {
+    error("Mandatory and should be a number")
+  }
+
+  if (!is.numeric(x)) {
     error("Mandatory and should be a number")
   }
 
@@ -226,6 +282,10 @@ valid_variance <- function(x, name = NULL, accept_na = FALSE, accept_null = TRUE
       return(NULL)
     }
     error(paste0("variance is NA", var_name))
+  }
+
+  if (!is.numeric(x)) {
+    error(paste0("variance is not a number", var_name))
   }
 
   if (x <= 0) {

--- a/src/fun/func_gameInit_validation.R
+++ b/src/fun/func_gameInit_validation.R
@@ -1,0 +1,48 @@
+# functions used to validate game initialisation parameters
+# these functions are defined here because they are used at 2 different
+# places:
+#  - The application, trhough the modules of each parameters
+#    with an `InputValidator` object (to highlight wrong inputs in the UI)
+#  - The Game Initialisation script (to stop it in case the inputs are wrong)
+#
+# Technically, the error messages should be slightly different if we raise an
+# error from the initialisation script or in the application. But since it
+# would complexify the code for few benefit the error messages to show on the
+# UI are implemented here (as it is the intended way to setup the game).
+#
+# These functions can either `stop` or `return` an error message.
+# The stop behaviour is intended to be used in the initialisation script
+# and the return behaviour is intended to be used with `InputValidator$add_rule`
+
+
+valid_rng_seed <- function(seed, accept_null = TRUE, raise_error = FALSE) {
+
+  error <- return
+  if (raise_error) {
+    error <- stop
+  }
+
+  if (is.null(seed)) {
+    if (accept_null) {
+      return(NULL)
+    }
+    error("Must not be NULL")
+  }
+
+  if (is.na(seed)) {
+    error("Mandatory and should be a positive integer")
+  }
+
+  if (!is.numeric(seed)) {
+    error("Should be a positive integer")
+  }
+
+  if (seed %% 1 != 0 || seed < 0) {
+    error("Should be a positive integer")
+  }
+
+  return(NULL)
+}
+
+
+

--- a/src/fun/func_gameInit_validation.R
+++ b/src/fun/func_gameInit_validation.R
@@ -44,5 +44,33 @@ valid_rng_seed <- function(seed, accept_null = TRUE, raise_error = FALSE) {
   return(NULL)
 }
 
+valid_positive_number <- function(x, accept_null = TRUE, raise_error = FALSE) {
+
+  error <- return
+  if (raise_error) {
+    error <- stop
+  }
+
+  if (is.null(x)) {
+    if (accept_null) {
+      return(NULL)
+    }
+    error("Must not be NULL")
+  }
+
+  if (is.na(x)) {
+    error("Mandatory and should be a positive number")
+  }
+
+  if (!is.numeric(x)) {
+    error("Should be a positive number")
+  }
+
+  if (x < 0) {
+    error("Should be a positive number")
+  }
+
+  return(NULL)
+}
 
 

--- a/src/fun/func_gameInit_validation.R
+++ b/src/fun/func_gameInit_validation.R
@@ -103,6 +103,53 @@ valid_number <- function(x, accept_null = TRUE, raise_error = FALSE) {
   return(NULL)
 }
 
+valid_range <- function(x, min, max, incl_min = TRUE, incl_max = TRUE, accept_null = TRUE, raise_error = FALSE) {
+
+  error <- return
+  if (raise_error) {
+    error <- stop
+  }
+
+  if (is.null(x)) {
+    if (accept_null) {
+      return(NULL)
+    }
+    error("Must not be NULL")
+  }
+
+  if (is.na(x)) {
+    error("Mandatory and should be a number")
+  }
+
+  min_msg <- paste(min, "(excluded)")
+  if (incl_min) {
+    min_msg <- paste(min, "(included)")
+  }
+  max_msg <- paste(max, "(excluded)")
+  if (incl_max) {
+    max_msg <- paste(max, "(included)")
+  }
+
+  err_msg <- paste("Should be between", min_msg, "and", max_msg)
+  if (x < min) {
+    error(err_msg)
+  }
+  if (x > max) {
+    error(err_msg)
+  }
+
+  if (!incl_min && x == min) {
+    error(err_msg)
+  }
+
+  if (!incl_max && x == max) {
+    error(err_msg)
+  }
+
+  return(NULL)
+
+}
+
 valid_mu <- function(x, accept_null = TRUE, raise_error = FALSE) {
   valid_number(x, accept_null, raise_error)
 }
@@ -140,25 +187,7 @@ valid_cv_g <- function(x, accept_null = TRUE, raise_error = FALSE) {
 }
 
 valid_h2 <- function(x, accept_null = TRUE, raise_error = FALSE) {
-  error <- return
-  if (raise_error) {
-    error <- stop
-  }
-
-  if (is.null(x)) {
-    if (accept_null) {
-      return(NULL)
-    }
-    error("Must not be NULL")
-  }
-
-  if (x <= 0) {
-    error("Should be strictly between 0 and 1")
-  }
-  if (x >= 1) {
-    error("Should be strictly between 0 and 1")
-  }
-  return(NULL)
+  valid_range(x, 0, 1, incl_min = FALSE, incl_max = FALSE, accept_null = accept_null, raise_error = raise_error)
 }
 
 
@@ -206,5 +235,12 @@ valid_variance <- function(x, name = NULL, accept_na = FALSE, accept_null = TRUE
     error(paste0("This value leads to an infinite variance", var_name))
   }
   return(NULL)
+}
+
+valid_prop_pleio <- function(x, accept_null = TRUE, raise_error = FALSE) {
+  valid_range(x, 0, 1, incl_min = TRUE, incl_max = TRUE, accept_null = accept_null, raise_error = raise_error)
+}
+valid_cor_pleio <-  function(x, accept_null = TRUE, raise_error = FALSE) {
+  valid_range(x, -1, 1, incl_min = TRUE, incl_max = TRUE, accept_null = accept_null, raise_error = raise_error)
 }
 

--- a/src/fun/func_gameInit_validation.R
+++ b/src/fun/func_gameInit_validation.R
@@ -44,7 +44,45 @@ valid_rng_seed <- function(seed, accept_null = TRUE, raise_error = FALSE) {
   return(NULL)
 }
 
-valid_positive_number <- function(x, accept_null = TRUE, raise_error = FALSE) {
+valid_positive_number <- function(x, strict = FALSE, accept_null = TRUE, raise_error = FALSE) {
+
+  error <- return
+  if (raise_error) {
+    error <- stop
+  }
+
+  if (is.null(x)) {
+    if (accept_null) {
+      return(NULL)
+    }
+    error("Must not be NULL")
+  }
+
+  strictly <- ""
+  if (strict) {
+    strictly <- "strictly "
+  }
+
+  if (is.na(x)) {
+    error(paste0("Mandatory and should be a ", strictly, "positive number"))
+  }
+
+  if (!is.numeric(x)) {
+    error(paste0("Should be a ", strictly, "positive number"))
+  }
+
+  if (x < 0) {
+    error(paste0("Should be a ", strictly, "positive number"))
+  }
+
+  if (strict && x == 0) {
+    error(paste0("Should be a ", strictly, "positive number"))
+  }
+
+  return(NULL)
+}
+
+valid_number <- function(x, accept_null = TRUE, raise_error = FALSE) {
 
   error <- return
   if (raise_error) {
@@ -59,18 +97,114 @@ valid_positive_number <- function(x, accept_null = TRUE, raise_error = FALSE) {
   }
 
   if (is.na(x)) {
-    error("Mandatory and should be a positive number")
-  }
-
-  if (!is.numeric(x)) {
-    error("Should be a positive number")
-  }
-
-  if (x < 0) {
-    error("Should be a positive number")
+    error("Mandatory and should be a number")
   }
 
   return(NULL)
 }
 
+valid_mu <- function(x, accept_null = TRUE, raise_error = FALSE) {
+  valid_number(x, accept_null, raise_error)
+}
+
+valid_Tmin <- function(x, mu, accept_null = TRUE, raise_error = FALSE) {
+  error <- return
+  if (raise_error) {
+    error <- stop
+  }
+
+  if (is.null(x)) {
+    if (accept_null) {
+      return(NULL)
+    }
+    error("Must not be NULL")
+  }
+
+  if (is.na(x)) {
+    error("Mandatory and should be a number")
+  }
+
+  if (is.na(mu)) {
+    return(NULL)
+  }
+
+  if (x >= mu) {
+    error(paste("Must be strictly lower than μ =", mu))
+  }
+
+  return(NULL)
+}
+
+valid_cv_g <- function(x, accept_null = TRUE, raise_error = FALSE) {
+  valid_positive_number(x, strict = TRUE, accept_null, raise_error)
+}
+
+valid_h2 <- function(x, accept_null = TRUE, raise_error = FALSE) {
+  error <- return
+  if (raise_error) {
+    error <- stop
+  }
+
+  if (is.null(x)) {
+    if (accept_null) {
+      return(NULL)
+    }
+    error("Must not be NULL")
+  }
+
+  if (x <= 0) {
+    error("Should be strictly between 0 and 1")
+  }
+  if (x >= 1) {
+    error("Should be strictly between 0 and 1")
+  }
+  return(NULL)
+}
+
+
+calc_sigma_p2 <- function(mu, min) {((mu - min)/3)^2}
+calc_sigma_a2 <- function(cv_g, mu) {(cv_g * mu)^2}
+calc_sigma2 <- function(h2, sigma_a2) {((1 - h2) / h2) * sigma_a2}
+calc_sigma_y2 <- function(sigma_p2, sigma_a2, sigma2) {sigma_p2 - sigma_a2 - sigma2}
+
+valid_variance <- function(x, name = NULL, accept_na = FALSE, accept_null = TRUE, raise_error = FALSE) {
+  error <- return
+  if (raise_error) {
+    error <- stop
+  }
+
+  if (length(x) == 0) {
+    if (accept_null) {
+      return(NULL)
+    }
+    error("No variance provided")
+  }
+
+  if (is.null(x)) {
+    if (accept_null) {
+      return(NULL)
+    }
+    error("Must not be NULL")
+  }
+
+  var_name = ""
+  if (!is.null(name)) {
+    var_name = paste(" for", name)
+  }
+
+  if (is.na(x)) {
+    if (accept_na) {
+      return(NULL)
+    }
+    error(paste0("variance is NA", var_name))
+  }
+
+  if (x <= 0) {
+    error(paste0("This value leads to negative variance", var_name))
+  }
+  if (x == Inf) {
+    error(paste0("This value leads to an infinite variance", var_name))
+  }
+  return(NULL)
+}
 

--- a/src/fun/module_constants.R
+++ b/src/fun/module_constants.R
@@ -16,8 +16,6 @@ constants_server <- function(const, constantsReactive) {
         tryCatch(
           {
             constants <- constantsReactive()
-            if (const == "") {
-            }
             if (const == "generations.per.year") {
               return(12 / constants$duration.allof)
             }

--- a/src/fun/module_constants.R
+++ b/src/fun/module_constants.R
@@ -26,8 +26,7 @@ constants_server <- function(const, constantsReactive) {
               return(format(constants$cost.register * constants$cost.pheno.field, digits = 2))
             }
             if (const == "initial.budget") {
-              # TODO, better to calculate this initial budget at game setup and save it in the db
-              return(format(constants$cost.pheno.field * constants$nb.plots * 10 * 1.3, digits = 2, scientific = F))
+              return(format(constants$initialBudget, digits = 2, scientific = F))
             }
             if (const == "cost.geno.single.mendels") {
               return(format(constants$cost.geno.single * constants$cost.pheno.field, digits = 2))

--- a/src/fun/module_gameInit_params.R
+++ b/src/fun/module_gameInit_params.R
@@ -82,6 +82,17 @@ gameInit_costs_ui <- function(id) {
 
   width_numInput <- "90%"
 
+  initBudget_label <- tooltip_label(
+    "Initial budget",
+    div(
+      p("The budget is not limiting for players.",
+        "If a player make a request without sufficient budget, the request",
+        "will be processed and player's remaining budget will be negative."
+      ),
+      p('This value can be changed durring the game in "Manage constant" tab.')
+    )
+  )
+
   div(
 
     collapible_section(
@@ -112,7 +123,7 @@ gameInit_costs_ui <- function(id) {
 
             h4("Other:", style = "margin-top: 20px;"),
             shiny::numericInput(ns("cost.register"), label = 'Final evaluation registration', value = 4, step = 0.1, width = width_numInput),
-            shiny::numericInput(ns("initialBudget"), label = "Initial budget", value = 3900, step = 100, width = width_numInput)
+            shiny::numericInput(ns("initialBudget"), label = initBudget_label, value = 3900, step = 100, width = width_numInput)
             # 3900 = 300 plots * 10 years + 30%
           ),
 

--- a/src/fun/module_gameInit_params.R
+++ b/src/fun/module_gameInit_params.R
@@ -663,10 +663,10 @@ gameInit_traits_server <- function(id, iv) {
       }
       input$t1_mu
     })
-    output$T1_sig_p2 <- renderText({round(T1_sig_p2(), 4)})
-    output$T1_sig_a2 <- renderText({round(T1_sig_a2(), 4)})
-    output$T1_sig2 <- renderText({round(T1_sig2(), 4)})
-    output$T1_sig_y2 <- renderText({round(T1_sig_y2(), 4)})
+    output$T1_sig_p2 <- renderText({signif(T1_sig_p2(), 6)})
+    output$T1_sig_a2 <- renderText({signif(T1_sig_a2(), 6)})
+    output$T1_sig2 <- renderText({signif(T1_sig2(), 6)})
+    output$T1_sig_y2 <- renderText({signif(T1_sig_y2(), 6)})
 
     output$T2_mu <- renderText({
       id = session$ns("prev_t2_mu")
@@ -677,10 +677,10 @@ gameInit_traits_server <- function(id, iv) {
       }
       input$t2_mu
     })
-    output$T2_sig_p2 <- renderText({round(T2_sig_p2(), 4)})
-    output$T2_sig_a2 <- renderText({round(T2_sig_a2(), 4)})
-    output$T2_sig2 <- renderText({round(T2_sig2(), 4)})
-    output$T2_sig_y2 <- renderText({round(T2_sig_y2(), 4)})
+    output$T2_sig_p2 <- renderText({signif(T2_sig_p2(), 6)})
+    output$T2_sig_a2 <- renderText({signif(T2_sig_a2(), 6)})
+    output$T2_sig2 <- renderText({signif(T2_sig2(), 6)})
+    output$T2_sig_y2 <- renderText({signif(T2_sig_y2(), 6)})
 
 
     output$pheno_plot <- renderPlotly({
@@ -766,11 +766,32 @@ gameInit_traits_server <- function(id, iv) {
 
       return(fig)
     })
+
+    return(
+      list(
+        value = reactive({
+          if (pheno_params_validator$is_valid()) {
+            return(list(
+              t1_mu = input$t1_mu,
+              t1_min = input$t1_min,
+              t1_cv_g = input$t1_cv_g,
+              t1_h2 = input$t1_h2,
+
+              t2_mu = input$t2_mu,
+              t2_min = input$t2_min,
+              t2_cv_g = input$t2_cv_g,
+              t2_h2 = input$t2_h2,
+
+              prop_pleio = input$prop_pleio,
+              cor_pleio = input$cor_pleio
+            ))
+          }
+          return(NA)
+        }),
+        iv = iv
+      )
+    )
+
   })
 }
-
-
-
-
-
 

--- a/src/fun/module_gameInit_params.R
+++ b/src/fun/module_gameInit_params.R
@@ -12,6 +12,7 @@
 
 library(shinyvalidate)
 library(shiny)
+library(plotly)
 
 tooltip_label <- function(label, description){
 
@@ -683,52 +684,81 @@ gameInit_traits_server <- function(id, iv) {
 
 
     output$pheno_plot <- renderPlotly({
-      T1_mu <- input$t1_mu
-      T1_min <- input$t1_min
-      T1_cv_g <- input$t1_cv_g
-      T1_h2 <- input$t1_h2
+      colors_T1 <- c("#1f77b4", "#ff7f0e")
+      colors_T2 <- c("#2ca02c", "#e12a2a")
+      if (!pheno_params_validator_T1$is_valid()) {
+        fig_T1 <- plot_ly(type = "box") %>%
+          add_annotations(
+            x=0.5, y=0.5, xref = "paper", yref = "paper",
+            text = "Error with trait 1",
+            xanchor = 'center',
+            showarrow = FALSE
+          )
+      } else {
+        T1_mu <- input$t1_mu
+        T1_min <- input$t1_min
+        T1_cv_g <- input$t1_cv_g
+        T1_h2 <- input$t1_h2
 
-      T2_mu <- input$t2_mu
-      T2_min <- input$t2_min
-      T2_cv_g <- input$t2_cv_g
-      T2_h2 <- input$t2_h2
+        data_t1 <- quick_pheno_simul(T1_mu, T1_min, T1_cv_g, T1_h2, seed = 1993)
 
-      data_t1 <- quick_pheno_simul(T1_mu, T1_min, T1_cv_g, T1_h2, seed = 1993)
-      data_t2 <- quick_pheno_simul(T2_mu, T2_min, T2_cv_g, T2_h2, seed = 42)
+        fig_T1 <- plot_ly(
+          data_t1,
+          x = ~year,
+          y = ~pheno,
+          type = 'box',
+          name = "Trait 1",
+          color = "a",
+          colors = colors_T1) %>% add_lines(
+            data = NULL,
+            type = "scatter",
+            y = T1_mu,
+            mode = "lines",
+            name = "μ T1",
+            color = "b")
+      }
+      fig_T1 <- fig_T1 %>% layout(
+        xaxis = list(title = "Year"),
+        yaxis = list(title = "Phenotypes Trait 1")
+      )
 
-      fig_T1 <- plot_ly(
-        data_t1,
-        x = ~year,
-        y = ~pheno,
-        type = 'box',
-        name = "Trait 1") %>% add_lines(
-          data = NULL,
-          type = "scatter",
-          y = T1_mu,
-          mode = "lines",
-          name = "μ T1") %>% layout(
-          xaxis = list(
-            title = "Year"
-          ),
-          yaxis = list(title = "Phenotypes Trait 1")
-        )
+      if (!pheno_params_validator_T2$is_valid()) {
+        fig_T2 <- plot_ly(type = "box") %>%
+          add_annotations(
+            x=0.5, y=0.5, xref = "paper", yref = "paper",
+            text = "Error with trait 2",
+            xanchor = 'center',
+            showarrow = F
+          )
+      } else {
+        T2_mu <- input$t2_mu
+        T2_min <- input$t2_min
+        T2_cv_g <- input$t2_cv_g
+        T2_h2 <- input$t2_h2
 
-      fig_T2 <- plot_ly(
-        data_t2,
-        x = ~year,
-        y = ~pheno,
-        type = 'box',
-        name = "Trait 2") %>% add_lines(
-          data = NULL,
-          type = "scatter",
-          y = T2_mu,
-          mode = "lines",
-          name = "μ T2") %>% layout(
-          xaxis = list(
-            title = "Year"
-          ),
-          yaxis = list(title = "Phenotypes Trait 2")
-        )
+        data_t2 <- quick_pheno_simul(T2_mu, T2_min, T2_cv_g, T2_h2, seed = 42)
+
+
+        fig_T2 <- plot_ly(
+          data_t2,
+          x = ~year,
+          y = ~pheno,
+          type = 'box',
+          name = "Trait 2",
+          color = "a",
+          colors = colors_T2) %>% add_lines(
+            data = NULL,
+            type = "scatter",
+            y = T2_mu,
+            mode = "lines",
+            name = "μ T2",
+            color = "b")
+      }
+
+      fig_T2 <- fig_T2 %>% layout(
+        xaxis = list(title = "Year"),
+        yaxis = list(title = "Phenotypes Trait 2")
+      )
 
       fig <- subplot(fig_T1, fig_T2, nrows = 2, titleX = TRUE, titleY = TRUE, margin = 0.1) %>% layout(
         title = "Example of phenotypic values\nfor the initial population"

--- a/src/fun/module_gameInit_params.R
+++ b/src/fun/module_gameInit_params.R
@@ -1,0 +1,38 @@
+
+# this file list all the game initialisation parameters (implemented in the
+# application)
+# It takes the forms of "shiny modules" to:
+#   - include the "input validation" in the module
+#   - have more complex UI that provides informations to users based on several
+#     "groups of inputs" (eg. all inputs related to budgets)
+#   - lighten the code related to "Admin server".
+
+# in the "server" parts of these modules, the `iv` argument is an
+# `InputValidator` object
+
+library(shinyvalidate)
+
+
+gameInit_seed_ui <- function(id) {
+  ns <- NS(id)
+  numericInput(ns("seed"), "RNG seed", value = 1993, step = 1)
+}
+
+gameInit_seed_server <- function(id, iv) {
+  moduleServer(id, function(input, output, session) {
+
+    iv$add_rule("seed", valid_rng_seed)
+    return(
+      list(
+        value = reactive({
+          if (is.null(iv$validate()[[session$ns('seed')]])) {
+            return(input$seed)
+          }
+          return(NA)
+        }),
+        iv = iv
+      )
+    )
+
+  })
+}

--- a/src/fun/module_gameInit_params.R
+++ b/src/fun/module_gameInit_params.R
@@ -12,10 +12,33 @@
 
 library(shinyvalidate)
 
+tooltip_label <- function(label, description){
+
+  tooltip <- tags$details(
+    tags$summary(style = "cursor: pointer;",
+     label, bsicons::bs_icon("question-circle")
+    ),
+    tags$blockquote(style = "font-weight: normal; font-size: inherit; font-style: italic;",
+      description
+    )
+  )
+}
 
 gameInit_seed_ui <- function(id) {
   ns <- NS(id)
-  numericInput(ns("seed"), "RNG seed", value = 1993, step = 1)
+
+  label <- tooltip_label(
+    "RNG seed",
+    div(
+      p("Random number generation seed."),
+      p("A positive integer used as a seed for random generation.",
+        "This ensures reproducibility of the game initialisation")
+    )
+  )
+  div(
+    # shiny::numericInput(ns("seed"), span("RNG seed", tooltip), value = 1993, step = 1)
+    shiny::numericInput(ns("seed"), label = label, value = 1993, step = 1)
+  )
 }
 
 gameInit_seed_server <- function(id, iv) {

--- a/src/fun/module_gameInit_params.R
+++ b/src/fun/module_gameInit_params.R
@@ -11,6 +11,7 @@
 # `InputValidator` object
 
 library(shinyvalidate)
+library(shiny)
 
 tooltip_label <- function(label, description){
 
@@ -240,4 +241,330 @@ gameInit_costs_server <- function(id, iv) {
 
   })
 }
+
+
+
+
+gameInit_traits_ui <- function(id) {
+  ns <- NS(id)
+
+  width_numInput <- "90%"
+
+  tooltip_label_min <- function(t){
+    # t is either 1 or 2
+    tooltip_label(
+      paste0("Min T", t),
+      div(
+        p(paste("Minimum value for Trait", t)),
+        p(HTML("Approximately 99% of the phenotypes of the initial population",
+          "will be above this value.",
+          "<br/>It will be used to calculate the variance of the phenotypes:",
+          "\\({\\sigma_p}^2 = ((\\mu - {Min_t}^T) / 3)^2\\)")
+        )
+      )
+    )
+  }
+  tooltip_label_mu <- function(t){
+    # t is either 1 or 2
+    tooltip_label(
+      paste0("μ T", t),
+      paste("Intercept for trait", t)
+    )
+  }
+  tooltip_label_gCV <- function(t){
+    # t is either 1 or 2
+    tooltip_label(
+      paste0("gCV T", t),
+      div(
+        p(paste("Genotypic coefficient of variation for trait", t)),
+        p(HTML("This value is used to calculate the genetic variance:",
+          "<br/>\\({\\sigma_a}^2 = (gCV * \\mu )^2\\)")
+        )
+      )
+    )
+  }
+  tooltip_label_h2 <- function(t){
+    # t is either 1 or 2
+    tooltip_label(
+      paste0("Heritability T", t),
+      div(
+        p("Intra-annual heritability"),
+        p(HTML("This value is used to calculate the variance of the errors \\(\\epsilon\\):",
+          "<br/>\\(\\sigma = \\frac{1-h^2}{h^2} {\\sigma_a}^2\\)")
+        )
+      )
+    )
+  }
+
+  div(
+    collapible_section(
+      title = "Phenotype simulation:",
+      title_id = ns("pheno_simul_title"),
+      div(
+        tags$blockquote(style = "font-weight: normal; font-size: inherit; font-style: italic;",
+        div(
+          h4("Quantitative traits simulation (T1 and T2)"),
+          p("The general model for simulating the phenotypes of quantitative traits (T1 and T2) is as follow:"),
+          p(withMathJax("$$y_{i,y,r} = \\mu + g_i + y_y + \\epsilon_{i,y,r}$$")),
+          p("Where:",
+            tags$ul(
+              tags$li(
+                "\\(y_{i,y,r}\\) is the phenotype value of the individual \\(i\\) at",
+                "year \\(y\\) for repetition \\(r\\)"
+              ),
+              tags$li(
+                "\\(\\mu\\) is the intercept values of the phenotype"
+              ),
+              tags$li(HTML(
+                "\\(g_i\\) is the genotypic value of the individual \\(i\\).",
+                "<br/>",
+                "This value is calculated based on the individual's genotypes",
+                "\\(x_{i,snp}\\) and the markers effects",
+                "\\(\\beta_{snp}\\): \\(g_i = \\sum_{snp} x_{i,snp}\\times\\beta_{snp}\\).",
+                "<br/> These markers effects \\(\\beta\\) are generated such as",
+                "the \\(g_i\\) of the initial population seems to be drawn from a normal distribution",
+                "\\(\\mathcal{N}(0, {\\sigma_{a}}^2)\\)"
+              )),
+              tags$li(
+                "\\(y_y\\) is the effect of the year \\(y\\) drawn from a normal distribution ",
+                "\\(\\mathcal{N}(0, {\\sigma_y}^2)\\)"
+              ),
+              tags$li(
+                "\\(\\epsilon_{i,y,r}\\) is a random noise drawn from a normal distribution ",
+                "\\(\\mathcal{N}(0, \\sigma^2)\\)"
+              )
+            )
+          ),
+          p("Some remarks:",
+            tags$ul(
+              tags$li(
+                  "T1 and T2 have pure additive infinitesimal genetic architecture",
+                  "and all SNPs (even the rarest) have a non-zero effect"
+                ),
+              tags$li(
+                  "There is no year/genotype interaction"
+                ),
+              tags$li(
+                  'There is no "plot" effect nor spatial heterogeneity',
+                  '(even if the phenotype data have a "plot" column)'
+                ),
+              tags$li(HTML(
+                  "The phenotypic variance of the initial population is:",
+                  "<br/>\\({\\sigma_p}^2 = {\\sigma_a}^2 + {\\sigma_y}^2 + \\sigma^2\\)")
+                )
+            )
+          )
+        )
+        ),
+
+        div(style = "display: flex;",
+          div(style = "flex: 1;",
+            h4("Trait 1 (Yield):", style = "margin-top: 20px;"),
+            shiny::numericInput(ns("t1_mu"), value = 100, step = 0.5, width = width_numInput,
+              label = tooltip_label_mu(1)
+            ),
+            shiny::numericInput(ns("t1_min"), value = 20, step = 0.5, width = width_numInput,
+              label = tooltip_label_min(1)
+            ),
+            shiny::numericInput(ns("t1_cv_g"), value = 0.10, step = 0.01, width = width_numInput,
+              label = tooltip_label_gCV(1)
+            ),
+            shiny::numericInput(ns("t1_h2"), value = 0.30, step = 0.01, width = width_numInput,
+              label = tooltip_label_h2(1)
+            ),
+
+            h4("Trait 2 (Quality):", style = "margin-top: 20px;"),
+            shiny::numericInput(ns("t2_mu"), value = 15, step = 0.5, width = width_numInput,
+              label = tooltip_label_mu(2)
+            ),
+            shiny::numericInput(ns("t2_min"), value = 5, step = 0.5, width = width_numInput,
+              label = tooltip_label_min(2)
+            ),
+            shiny::numericInput(ns("t2_cv_g"), value = 0.06, step = 0.01, width = width_numInput,
+              label = tooltip_label_gCV(2)
+            ),
+            shiny::numericInput(ns("t2_h2"), value = 0.60, step = 0.01, width = width_numInput,
+              label = tooltip_label_h2(2)
+            ),
+
+            h4("Trait 1/2 pleiotropy:", style = "margin-top: 20px;"),
+            shiny::numericInput(ns("prop_pleio"), value = 0.4, step = 0.01, width = width_numInput, label = 'Proportion of pleiotropy'),
+            shiny::numericInput(ns("cor_pleio"), value = -0.7, step = 0.01, width = width_numInput, label = 'Pleiotropy correlation'),
+
+          ),
+
+          div(style = "flex: 1;",
+            h4("Informations", style = "margin-top: 20px;"),
+            tags$blockquote(style = "font-weight: normal; font-size: inherit; font-style: italic;",
+              h4("Models parameters:"),
+              div(style = "display: flex;",
+                div(style = "flex: 1;",
+                  h5("Trait 1:"),
+                  tags$ul(
+                    tags$li("\\(\\mu =\\)", textOutput(ns("T1_mu"), inline = T)),
+                    tags$li("\\({\\sigma_p}^2 =\\)", textOutput(ns("T1_sig_p"), inline = T)),
+                    tags$li("\\({\\sigma_a}^2 =\\)", textOutput(ns("T1_sig_a"), inline = T)),
+                    tags$li("\\({\\sigma}^2 =\\)", textOutput(ns("T1_sig"), inline = T)),
+                    tags$li("\\({\\sigma_y}^2 =\\)", textOutput(ns("T1_sig_y"), inline = T))
+                  )
+                ),
+                div(style = "flex: 1;",
+                  h5("Trait 2:"),
+                  tags$ul(
+                    tags$li("\\(\\mu =\\)", textOutput(ns("T2_mu"), inline = T)),
+                    tags$li("\\({\\sigma_p}^2 =\\)", textOutput(ns("T2_sig_p"), inline = T)),
+                    tags$li("\\({\\sigma_a}^2 =\\)", textOutput(ns("T2_sig_a"), inline = T)),
+                    tags$li("\\({\\sigma}^2 =\\)", textOutput(ns("T2_sig"), inline = T)),
+                    tags$li("\\({\\sigma_y}^2 =\\)", textOutput(ns("T2_sig_y"), inline = T))
+                  )
+                )
+              )
+            ),
+            plotlyOutput(ns("pheno_plot"), width = "100%")
+          )
+        )
+      )
+    )
+  )
+}
+
+quick_pheno_simul <- function(mu, min, cv_g, h2) {
+
+  saved_seed <- .Random.seed
+  set.seed(1993)
+  n_inds <- 100
+  n_years <- 5
+  first_year <- 1
+
+  sig_p <- calc_sigma_p(mu, min)
+  sig_a <- calc_sigma_a(cv_g, mu)
+  sig <- calc_sigma(h2, sig_a)
+  sig_y <- calc_sigma_y(sig_p, sig_a, sig)
+
+  df <- data.frame(
+    i = seq(1, n_inds),
+    g = rnorm(n_inds, 0, sqrt(sig_a))
+  )
+
+  df <- do.call(rbind, lapply(seq(first_year, first_year + n_years), function(year) {
+    y_eff <- rnorm(1, 0, sqrt(sig_y))
+    df$year <- year
+    df$year_eff <- y_eff
+    df$pheno <- mu + df$g + y_eff + rnorm(n_inds, 0, sqrt(sig))
+    df
+  }))
+  df$year <- as.character(df$year)
+
+  set.seed(saved_seed)
+  return(df)
+}
+
+calc_sigma_p <- function(mu, min) {((mu - min)/3)^2}
+calc_sigma_a <- function(cv_g, mu) {(cv_g * mu)^2}
+calc_sigma <- function(h2, sigma_a) {((1 - h2) / h2) * sigma_a}
+calc_sigma_y <-  function(sigma_p, sigma_a, sigma) {sigma_p - sigma_a - sigma}
+
+gameInit_traits_server <- function(id, iv) {
+  moduleServer(id, function(input, output, session) {
+
+
+    pheno_params_validator <- InputValidator$new()
+    # pheno_params_validator$add_rule("t1_mu", sv_integer())
+
+    iv$add_validator(pheno_params_validator)
+
+
+    output$T1_mu <- renderText({input$t1_mu})
+    output$T1_sig_p <- renderText({
+      round(calc_sigma_p(input$t1_mu, input$t1_min), 4)
+    })
+    output$T1_sig_a <- renderText({calc_sigma_a(input$t1_cv_g, input$t1_mu)})
+    output$T1_sig <- renderText({
+      T1_sig_a <- calc_sigma_a(input$t1_cv_g, input$t1_mu)
+      round(calc_sigma(input$t1_h2, T1_sig_a), 4)
+    })
+    output$T1_sig_y <- renderText({
+      T1_sig_p <- calc_sigma_p(input$t1_mu, input$t1_min)
+      T1_sig_a <- calc_sigma_a(input$t1_cv_g, input$t1_mu)
+      T1_sig <- calc_sigma(input$t1_h2, T1_sig_a)
+      round(calc_sigma_y(T1_sig_p, T1_sig_a, T1_sig), 4)
+    })
+    output$T2_mu <- renderText({input$t2_mu})
+    output$T2_sig_p <- renderText({
+      round(calc_sigma_p(input$t2_mu, input$t2_min), 4)
+    })
+    output$T2_sig_a <- renderText({calc_sigma_a(input$t2_cv_g, input$t2_mu)})
+    output$T2_sig <- renderText({
+      T2_sig_a <- calc_sigma_a(input$t2_cv_g, input$t2_mu)
+      round(calc_sigma(input$t2_h2, T2_sig_a), 4)
+    })
+    output$T2_sig_y <- renderText({
+      T2_sig_p <- calc_sigma_p(input$t2_mu, input$t2_min)
+      T2_sig_a <- calc_sigma_a(input$t2_cv_g, input$t2_mu)
+      T2_sig <- calc_sigma(input$t2_h2, T2_sig_a)
+      round(calc_sigma_y(T2_sig_p, T2_sig_a, T2_sig), 4)
+    })
+
+
+    output$pheno_plot <- renderPlotly({
+      T1_mu <- input$t1_mu
+      T1_min <- input$t1_min
+      T1_cv_g <- input$t1_cv_g
+      T1_h2 <- input$t1_h2
+
+      T2_mu <- input$t2_mu
+      T2_min <- input$t2_min
+      T2_cv_g <- input$t2_cv_g
+      T2_h2 <- input$t2_h2
+
+      data_t1 <- quick_pheno_simul(T1_mu, T1_min, T1_cv_g, T1_h2)
+      data_t2 <- quick_pheno_simul(T2_mu, T2_min, T2_cv_g, T2_h2)
+
+      fig_T1 <- plot_ly(
+        data_t1,
+        x = ~year,
+        y = ~pheno,
+        type = 'box',
+        name = "Trait 1") %>% add_lines(
+          data = NULL,
+          type = "scatter",
+          y = T1_mu,
+          mode = "lines",
+          name = "μ T1") %>% layout(
+          xaxis = list(
+            title = "Year"
+          ),
+          yaxis = list(title = "Phenotypes Trait 1")
+        )
+
+      fig_T2 <- plot_ly(
+        data_t2,
+        x = ~year,
+        y = ~pheno,
+        type = 'box',
+        name = "Trait 2") %>% add_lines(
+          data = NULL,
+          type = "scatter",
+          y = T2_mu,
+          mode = "lines",
+          name = "μ T2") %>% layout(
+          xaxis = list(
+            title = "Year"
+          ),
+          yaxis = list(title = "Phenotypes Trait 2")
+        )
+
+      fig <- subplot(fig_T1, fig_T2, nrows = 2, titleX = TRUE, titleY = TRUE, margin = 0.1) %>% layout(
+        title = "Simulated phenotypic values for the initial population"
+      )
+
+      return(fig)
+    })
+  })
+}
+
+
+
+
+
 

--- a/src/fun/module_gameInit_params.R
+++ b/src/fun/module_gameInit_params.R
@@ -24,6 +24,20 @@ tooltip_label <- function(label, description){
   )
 }
 
+collapible_section <- function(title, title_id, content) {
+
+  tags$details(style = "margin-top: 30px;",
+    tags$summary(
+      h3(title, "(click to expand)",
+         style = "margin-top: 0px; display: inline-block;",
+         id = title_id
+      )
+    ),
+    content
+  )
+
+}
+
 gameInit_seed_ui <- function(id) {
   ns <- NS(id)
 
@@ -36,7 +50,7 @@ gameInit_seed_ui <- function(id) {
     )
   )
   div(
-    # shiny::numericInput(ns("seed"), span("RNG seed", tooltip), value = 1993, step = 1)
+    h3("", style = "margin-top: 30px;"),
     shiny::numericInput(ns("seed"), label = label, value = 1993, step = 1)
   )
 }
@@ -59,3 +73,160 @@ gameInit_seed_server <- function(id, iv) {
 
   })
 }
+
+
+
+gameInit_costs_ui <- function(id) {
+  ns <- NS(id)
+
+
+  width_numInput <- "90%"
+
+  div(
+
+    collapible_section(
+      title = "Costs and budget:",
+      title_id = ns("cost_budget_title"),
+      div(
+        tags$blockquote(style = "font-weight: normal; font-size: inherit; font-style: italic;",
+          p("Note: Unless explicitly mentioned, all costs are expressed",
+            strong("relative to the cost of phenotyping one plot"),
+            ".")
+        ),
+
+        div(style = "display: flex;",
+          div(style = "flex: 1;",
+            h4("Phenotyping:", style = "margin-top: 20px;"),
+            shiny::numericInput(ns("cost.pheno.field"), label = "Field phenotyping for 1 plot (in Mendels)", value = 50, step = 1, width = width_numInput),
+            shiny::numericInput(ns("cost.pheno.patho"), label = 'Pathogene phenotyping', value = 0.1, step = 0.1, width = width_numInput),
+
+            h4("Crossing:", style = "margin-top: 20px;"),
+            shiny::numericInput(ns("cost.allof"), label = 'Allo-fecundation', value = 0.1, step = 0.1, width = width_numInput),
+            shiny::numericInput(ns("cost.autof"), label = 'Auto-fecundation', value = 0.25, step = 0.1, width = width_numInput),
+            shiny::numericInput(ns("cost.haplodiplo"), label = 'Haplo-diploidisation', value = 1, step = 0.1, width = width_numInput),
+
+            h4("Genotyping:", style = "margin-top: 20px;"),
+            shiny::numericInput(ns("cost.geno.hd"), label = 'Genotyping HD', value = 1, step = 0.1, width = width_numInput),
+            shiny::numericInput(ns("cost.geno.ld"), label = 'Genotyping LD', value = 0.5, step = 0.1, width = width_numInput),
+            shiny::numericInput(ns("cost.geno.single"), label = 'Genotyping single SNP', value = 0.02, step = 0.1, width = width_numInput),
+
+            h4("Other:", style = "margin-top: 20px;"),
+            shiny::numericInput(ns("cost.register"), label = 'Final evaluation registration', value = 4, step = 0.1, width = width_numInput),
+            shiny::numericInput(ns("initialBudget"), label = "Initial budget", value = 3900, step = 100, width = width_numInput)
+            # 3900 = 300 plots * 10 years + 30%
+          ),
+
+          div(style = "flex: 1;",
+            h4("Cost and budget summary", style = "margin-top: 20px;"),
+            tableOutput(ns("costs_table")),
+            tags$blockquote(style = "font-weight: normal; font-size: inherit; font-style: italic;",
+              textOutput(ns("init_budget_summary"))
+            )
+          )
+        )
+      )
+    )
+  )
+
+
+}
+
+gameInit_costs_server <- function(id, iv) {
+  moduleServer(id, function(input, output, session) {
+
+    output$costs_table <- renderTable({
+      cost_df <- data.frame(
+        Plot = c(
+          1,
+          input$cost.pheno.patho,
+          input$cost.allof,
+          input$cost.autof,
+          input$cost.haplodiplo,
+          input$cost.geno.hd,
+          input$cost.geno.ld,
+          input$cost.geno.single,
+          input$cost.register,
+          input$initialBudget
+        ),
+        row.names = c(
+          "Phenotyping plot",
+          "Phenotyping pathogene",
+          "Allo-fecundation",
+          "Auto-fecundation",
+          "Haplo-diploidisation",
+          "Genotyping HD",
+          "Genotyping LD",
+          "Genotyping single SNP",
+          "Registration",
+          "Initial Budget"
+        )
+      )
+      cost_df$Mendels <- cost_df$Plot * input$cost.pheno.field
+      return(cost_df)
+    }, rownames = TRUE)
+
+    output$init_budget_summary <- renderText({
+      n_plot <- 300 # TODO used game init parameter instead
+      n_year <- 10
+      initB <- input$initialBudget
+
+      bonus <- ((initB / (n_plot * n_year)) - 1) * 100
+
+      paste0("Initial budget represents ",
+        n_plot, " phenotyping plots for ",
+        n_year, " years ",
+        sprintf("%+.0f%%", bonus), "."
+      )
+    })
+
+    cost_validator <- InputValidator$new()
+    cost_validator$add_rule("cost.pheno.field", valid_positive_number)
+    cost_validator$add_rule("cost.pheno.patho", valid_positive_number)
+    cost_validator$add_rule("cost.allof", valid_positive_number)
+    cost_validator$add_rule("cost.autof", valid_positive_number)
+    cost_validator$add_rule("cost.haplodiplo", valid_positive_number)
+    cost_validator$add_rule("cost.geno.hd", valid_positive_number)
+    cost_validator$add_rule("cost.geno.ld", valid_positive_number)
+    cost_validator$add_rule("cost.geno.single", valid_positive_number)
+    cost_validator$add_rule("cost.register", valid_positive_number)
+    cost_validator$add_rule("initialBudget", valid_positive_number)
+
+    iv$add_validator(cost_validator)
+
+    observe({
+      id = session$ns('cost_budget_title')
+      if (cost_validator$is_valid()) {
+        # shinyjs::removeClass(id, "has-error") # not working in modules
+        shinyjs::runjs(code = paste0('$("#', id, '").removeClass("has-error");'))
+      } else {
+        # shinyjs::addClass(id, "has-error") # not working in modules
+        shinyjs::runjs(code = paste0('$("#', id, '").addClass("has-error");'))
+      }
+    })
+
+    return(
+      list(
+        value = reactive({
+          if (cost_validator$is_valid()) {
+            return(list(
+              cost.pheno.field = input$cost.pheno.field,
+              cost.pheno.patho = input$cost.pheno.patho,
+              cost.allof = input$cost.allof,
+              cost.autof = input$cost.autof,
+              cost.haplodiplo = input$cost.haplodiplo,
+              cost.geno.hd = input$cost.geno.hd,
+              cost.geno.ld = input$cost.geno.ld,
+              cost.geno.single = input$cost.geno.single,
+              cost.register = input$cost.register,
+              initialBudget = input$initialBudget
+            ))
+          }
+          return(NA)
+        }),
+        iv = iv
+      )
+    )
+
+  })
+}
+

--- a/src/plantbreedgame_setup.Rmd
+++ b/src/plantbreedgame_setup.Rmd
@@ -4,6 +4,7 @@ author: "Timothée Flutre (INRA)"
 date: "`r format(Sys.time(), '%d/%m/%Y %H:%M:%S')`"
 params:
   progressBar: NULL
+  rng_seed: 1993
 colorlinks: true
 output:
   html_document:
@@ -11,6 +12,7 @@ output:
     toc_depth: 4
     toc_float: true
     number_sections: TRUE
+    code_folding: hide
   pdf_document:
     toc: true
     toc_depth: 4
@@ -99,15 +101,28 @@ suppressPackageStartupMessages(library(scrm)) # from CRAN
 suppressPackageStartupMessages(library(GenomicRanges)) # from bioconductor
 
 source("fun/functions.R")
+source("fun/module_gameInit_params.R")
+source("fun/func_gameInit_validation.R")
+
 ```
 
-Set the seed:
+# Parameters
+
+Validation and overview of the parameters used to initialised this game session.
+
 ```{r}
-RNGkind("L'Ecuyer-CMRG") # to make mclapply reproducible
-set.seed(1993) # better to change it from one game session to the next
+progressBar$set(
+  value = progressBar$getValue() + 1,
+  detail = "Parameter validation..."
+)
+
+valid_rng_seed(params$rng_seed, accept_null = FALSE, raise_error = TRUE)
+
+print(params[names(params) != "progressBar"])
 ```
 
-Set up directories:
+# Set up data directories and RNG seed
+
 ```{r setup_dir}
 progressBar$set(
   value = progressBar$getValue() + 1,
@@ -133,7 +148,12 @@ dir.create(truth.dir)
 dir.create(shared.dir)
 dir.create(init.dir)
 dir.create(reports.dir)
+```
 
+
+```{r}
+RNGkind("L'Ecuyer-CMRG") # to make mclapply reproducible
+set.seed(params$rng_seed)
 ```
 
 # Create initial breeders

--- a/src/plantbreedgame_setup.Rmd
+++ b/src/plantbreedgame_setup.Rmd
@@ -17,9 +17,6 @@ output:
     number_sections: TRUE
 ---
 
-<!--
-This R chunk is used to set up important options and load required packages.
--->
 ```{r setup, include=FALSE}
 progressBar <- params$progressBar
 
@@ -30,8 +27,6 @@ if (is.null(progressBar)) {
   )
 }
 
-
-
 R.v.maj <- as.numeric(R.version$major)
 R.v.min.1 <- as.numeric(strsplit(R.version$minor, "\\.")[[1]][1])
 if (R.v.maj < 2 || (R.v.maj == 2 && R.v.min.1 < 15)) {
@@ -39,9 +34,19 @@ if (R.v.maj < 2 || (R.v.maj == 2 && R.v.min.1 < 15)) {
 }
 
 suppressPackageStartupMessages(library(knitr))
-opts_chunk$set(echo = TRUE, warning = TRUE, message = TRUE, cache = FALSE, fig.align = "center")
+opts_chunk$set(
+  echo = TRUE,
+  warning = TRUE,
+  message = TRUE,
+  cache = FALSE,
+  fig.align = "center",
+  results = "hold",
+  strip.white = TRUE
+)
 
 options(stringsAsFactors = TRUE) # R-4.0.0 compatibility
+
+t0 <- proc.time()
 ```
 
 
@@ -57,13 +62,8 @@ It sets up a [serious game](https://sourcesup.renater.fr/plantbreedgame/) to tea
 
 # Set up the environment
 
-This R chunk is used to assess how much time it takes to execute the R code in this document until the end:
-```{r time_0}
-t0 <- proc.time()
-```
+```{r load_pkgs}
 
-Load the packages:
-```{r load_pkg}
 progressBar$set(
   value = progressBar$getValue() + 1,
   detail = "Load R packages..."
@@ -136,6 +136,8 @@ dir.create(reports.dir)
 
 ```
 
+# Create initial breeders
+
 Create the "admin" and "test" players (other players are created via the interface):
 ```{r}
 breeders <- c("admin", "test")
@@ -164,15 +166,16 @@ ind.ids <- sprintf(fmt = paste0("ind%0", floor(log10(I)) + 1, "i"), 1:I)
 
 Simulate haplotypes and genotypes of initial individuals:
 
-* hyp: single pop
+- hypothesis: single pop
 
-* hyp: no inter-chrom LD
+- hypothesis: no inter-chrom LD
 
-* hyp: all chroms have the same length
+- hypothesis: all chroms have the same length
 
-* hyp: individuals are diploids
+- hypothesis: individuals are diploids
 
-* scaling: measure time in units of 4 x N_e generations
+- scaling: measure time in units of `4 * N_e` generations
+
 
 ```{r init_chrs}
 nb.chrs <- 10
@@ -379,7 +382,7 @@ Enhancement: panmixia with, say, 40 genotypes for 3 generations
 
 Ascertain SNPs for the genotyping arrays (high and low density):
 
-* hyp: mimick de novo sequencing of a few individuals
+- hypothesis: mimick de novo sequencing of a few individuals
 
 ```{r ascertain_snps}
 nb.inds.denovo <- 20

--- a/src/plantbreedgame_setup.Rmd
+++ b/src/plantbreedgame_setup.Rmd
@@ -23,6 +23,7 @@ output:
     toc_float: true
     number_sections: TRUE
     code_folding: hide
+    self_contained: yes
   pdf_document:
     toc: true
     toc_depth: 4

--- a/src/plantbreedgame_setup.Rmd
+++ b/src/plantbreedgame_setup.Rmd
@@ -15,6 +15,16 @@ params:
   cost.geno.single: 0.02
   cost.register: 4
   initialBudget: 3900
+  t1_mu: 20
+  t1_min: 100
+  t1_cv_g: 0.1
+  t1_h2: 0.3
+  t2_mu: 15
+  t2_min: 5
+  t2_cv_g: 0.06
+  t2_h2: 0.6
+  prop_pleio: 0.4
+  cor_pleio: -0.7
 colorlinks: true
 output:
   html_document:
@@ -140,6 +150,38 @@ invisible({
   valid_positive_number(params$cost.geno.single, accept_null = FALSE, raise_error = TRUE)
   valid_positive_number(params$cost.register, accept_null = FALSE, raise_error = TRUE)
   valid_positive_number(params$initialBudget, accept_null = FALSE, raise_error = TRUE)
+
+  valid_mu(params$t1_mu, accept_null = FALSE, raise_error = TRUE)
+  valid_Tmin(params$t1_min, params$t1_mu, accept_null = FALSE, raise_error = TRUE)
+  valid_cv_g(params$t1_cv_g, accept_null = FALSE, raise_error = TRUE)
+  valid_h2(params$t1_h2, accept_null = FALSE, raise_error = TRUE)
+
+  valid_mu(params$t2_mu, accept_null = FALSE, raise_error = TRUE)
+  valid_Tmin(params$t2_min, params$t2_mu, accept_null = FALSE, raise_error = TRUE)
+  valid_cv_g(params$t2_cv_g, accept_null = FALSE, raise_error = TRUE)
+  valid_h2(params$t2_h2, accept_null = FALSE, raise_error = TRUE)
+
+  t1_sig_p2 <- calc_sigma_p2(params$t1_mu, params$t1_min)
+  valid_variance(t1_sig_p2, "phenotypes T1", accept_na = FALSE, accept_null = FALSE, raise_error = TRUE)
+  t1_sig_a2 <- calc_sigma_a2(params$t1_cv_g, params$t1_mu)
+  valid_variance(t1_sig_a2, "genetic values T1", accept_na = FALSE, accept_null = FALSE, raise_error = TRUE)
+  t1_sig2 <- calc_sigma2(params$t1_h2, t1_sig_a2)
+  valid_variance(t1_sig2, "noise T1", accept_na = FALSE, accept_null = FALSE, raise_error = TRUE)
+  t1_sig_y2 <- calc_sigma_y2(t1_sig_p2, t1_sig_a2, t1_sig2 )
+  valid_variance(t1_sig_y2, "year effects T1", accept_na = FALSE, accept_null = FALSE, raise_error = TRUE)
+
+  t2_sig_p2 <- calc_sigma_p2(params$t2_mu, params$t2_min)
+  valid_variance(t2_sig_p2, "phenotypes T2", accept_na = FALSE, accept_null = FALSE, raise_error = TRUE)
+  t2_sig_a2 <- calc_sigma_a2(params$t2_cv_g, params$t2_mu)
+  valid_variance(t2_sig_a2, "genetic values T2", accept_na = FALSE, accept_null = FALSE, raise_error = TRUE)
+  t2_sig2 <- calc_sigma2(params$t2_h2, t2_sig_a2)
+  valid_variance(t2_sig2, "noise T2", accept_na = FALSE, accept_null = FALSE, raise_error = TRUE)
+  t2_sig_y2 <- calc_sigma_y2(t2_sig_p2, t2_sig_a2, t2_sig2 )
+  valid_variance(t2_sig_y2, "year effects T2", accept_na = FALSE, accept_null = FALSE, raise_error = TRUE)
+
+  valid_prop_pleio(params$prop_pleio, accept_null = FALSE, raise_error = TRUE)
+  valid_cor_pleio(params$cor_pleio, accept_null = FALSE, raise_error = TRUE)
+
 })
 
 print(params[names(params) != "progressBar"])
@@ -742,13 +784,13 @@ Here is the procedure for trait 1 of setting the variances required by the gener
 We set the initial phenotypic mean, $\mu_p$, to a global intercept which will be held constant during the whole game: $\mu_p = \mu$.
 
 ```{r simul_proc_t1_mu}
-(mu <- 100)
+(mu <- params$t1_mu)
 ```
 
 We set the individual-plant phenotypic variance so that approximately 99% of all the phenotypes are above a minimal value: $\mu - 3 \sigma_p \ge y_{\text{min}}$.
 
 ```{r simul_proc_t1_sigma_p2}
-y.min <- 20
+y.min <- params$t1_min
 (sigma.p2 <- ((mu - y.min) / 3)^2)
 sqrt(sigma.p2)
 ```
@@ -777,7 +819,7 @@ We deduce the genotypic coef of variation:
 
 However, because the previous computations don't account for the negative correlation between traits, we still fix the CVg by hand at this point:
 ```{r}
-CV.g <- 0.10
+CV.g <- params$t1_cv_g
 ```
 
 We deduce the (additive) genotypic variance:
@@ -791,7 +833,7 @@ stopifnot(sigma.a2 < sigma.p2)
 We deduce the error variance given that the intra-annual, individual-plant heritability is set at a particular value: $h^2 = \frac{\sigma_a^2}{\sigma_a^2 + \sigma^2}$.
 
 ```{r simul_proc_t1_sigma2}
-h2 <- 0.3
+h2 <- params$t1_h2
 (sigma2 <- ((1 - h2) / h2) * sigma.a2)
 sqrt(sigma2)
 stopifnot(sigma2 + sigma.a2 < sigma.p2)
@@ -839,13 +881,13 @@ Here is the procedure for trait 2 of setting the variances required by the gener
 We fix the initial phenotypic mean, $\mu_p$, to a global intercept which will be held constant during the whole game: $\mu_p = \mu$.
 
 ```{r simul_proc_t2_mu}
-(mu <- 15)
+(mu <- params$t2_mu)
 ```
 
 We deduce the individual-plant phenotypic variance so that approximately 99% of all the phenotypes are above a minimal value: $\mu - 3 \sigma_p \ge y_{\text{min}}$.
 
 ```{r simul_proc_t2_sigma_p2}
-y.min <- 5
+y.min <- params$t2_min
 (sigma.p2 <- ((mu - y.min) / 3)^2)
 sqrt(sigma.p2)
 ```
@@ -859,7 +901,7 @@ register.min.trait2 <- mu
 We deduce the (additive) genotypic variance given that the genotypic coef of variation is set at a particular value:
 
 ```{r simul_proc_t2_sigma_a2}
-CV.g <- 0.06
+CV.g <- params$t2_cv_g
 (sigma.a2 <- (CV.g * mu)^2)
 sqrt(sigma.a2)
 stopifnot(sigma.a2 < sigma.p2)
@@ -868,7 +910,7 @@ stopifnot(sigma.a2 < sigma.p2)
 We deduce the error variance given that the intra-annual, individual-plant heritability is set at a particular value: $h^2 = \frac{\sigma_a^2}{\sigma_a^2 + \sigma^2}$.
 
 ```{r simul_proc_t2_sigma2}
-h2 <- 0.6
+h2 <- params$t2_h2
 (sigma2 <- ((1 - h2) / h2) * sigma.a2)
 sqrt(sigma2)
 stopifnot(sigma2 + sigma.a2 < sigma.p2)
@@ -920,7 +962,7 @@ Simulate the SNP effects for traits 1 and 2 jointly:
 snp.effects12 <- simulSnpEffectsTraits12(
   snp.ids = thin.snps,
   sigma.beta2 = sigma.beta2,
-  prop.pleio = 0.4, cor.pleio = -0.7
+  prop.pleio = params$prop_pleio, cor.pleio = params$cor_pleio
 )
 ```
 

--- a/src/plantbreedgame_setup.Rmd
+++ b/src/plantbreedgame_setup.Rmd
@@ -5,6 +5,16 @@ date: "`r format(Sys.time(), '%d/%m/%Y %H:%M:%S')`"
 params:
   progressBar: NULL
   rng_seed: 1993
+  cost.pheno.field: 50
+  cost.pheno.patho: 0.1
+  cost.allof: 0.1
+  cost.autof: 0.25
+  cost.haplodiplo: 1
+  cost.geno.hd: 1
+  cost.geno.ld: 0.5
+  cost.geno.single: 0.02
+  cost.register: 4
+  initialBudget: 3900
 colorlinks: true
 output:
   html_document:
@@ -24,8 +34,8 @@ progressBar <- params$progressBar
 
 if (is.null(progressBar)) {
   progressBar <- list(
-    set = function(...){return(NULL)},
-    getValue = function(...){return(NULL)}
+    set = function(...){return(invisible(NULL))},
+    getValue = function(...){return(invisible(NULL))}
   )
 }
 
@@ -116,7 +126,20 @@ progressBar$set(
   detail = "Parameter validation..."
 )
 
-valid_rng_seed(params$rng_seed, accept_null = FALSE, raise_error = TRUE)
+invisible({
+  valid_rng_seed(params$rng_seed, accept_null = FALSE, raise_error = TRUE)
+
+  valid_positive_number(params$cost.pheno.field, accept_null = FALSE, raise_error = TRUE)
+  valid_positive_number(params$cost.pheno.patho, accept_null = FALSE, raise_error = TRUE)
+  valid_positive_number(params$cost.allof, accept_null = FALSE, raise_error = TRUE)
+  valid_positive_number(params$cost.autof, accept_null = FALSE, raise_error = TRUE)
+  valid_positive_number(params$cost.haplodiplo, accept_null = FALSE, raise_error = TRUE)
+  valid_positive_number(params$cost.geno.hd, accept_null = FALSE, raise_error = TRUE)
+  valid_positive_number(params$cost.geno.ld, accept_null = FALSE, raise_error = TRUE)
+  valid_positive_number(params$cost.geno.single, accept_null = FALSE, raise_error = TRUE)
+  valid_positive_number(params$cost.register, accept_null = FALSE, raise_error = TRUE)
+  valid_positive_number(params$initialBudget, accept_null = FALSE, raise_error = TRUE)
+})
 
 print(params[names(params) != "progressBar"])
 ```
@@ -1512,45 +1535,44 @@ res <- dbExecute(conn = db, query)
 
 Fill the table with the constants specifying the costs:
 ```{r table_constants_fill_costs}
-cost.pheno.field <- 50
 query <- paste0(
   "INSERT INTO ", tbl, " VALUES",
-  " ('cost.pheno.field', '", cost.pheno.field, "')"
+  " ('cost.pheno.field', '", params$cost.pheno.field, "')"
 ) # in Mendels
 res <- dbExecute(conn = db, query)
 query <- paste0(
   "INSERT INTO ", tbl, " VALUES",
-  " ('cost.pheno.patho', '", 1 / 10, "')"
+  " ('cost.pheno.patho', '", params$cost.pheno.patho, "')"
 ) # compare to one plot
 res <- dbExecute(conn = db, query)
 query <- paste0(
   "INSERT INTO ", tbl, " VALUES",
-  " ('cost.allof', '", 1 / 10, "')"
+  " ('cost.allof', '", params$cost.allof, "')"
 ) # idem
 res <- dbExecute(conn = db, query)
 query <- paste0(
   "INSERT INTO ", tbl, " VALUES",
-  " ('cost.autof', '", 1 / 25, "')"
+  " ('cost.autof', '", params$cost.autof, "')"
 ) # idem
 res <- dbExecute(conn = db, query)
 query <- paste0(
   "INSERT INTO ", tbl, " VALUES",
-  " ('cost.haplodiplo', '", 1, "')"
+  " ('cost.haplodiplo', '", params$cost.haplodiplo, "')"
 ) # idem
 res <- dbExecute(conn = db, query)
 query <- paste0(
   "INSERT INTO ", tbl, " VALUES",
-  " ('cost.geno.hd', '", 1, "')"
+  " ('cost.geno.hd', '", params$cost.geno.hd, "')"
 ) # idem
 res <- dbExecute(conn = db, query)
 query <- paste0(
   "INSERT INTO ", tbl, " VALUES",
-  " ('cost.geno.ld', '", 1 / 2, "')"
+  " ('cost.geno.ld', '", params$cost.geno.ld, "')"
 ) # idem
 res <- dbExecute(conn = db, query)
 query <- paste0(
   "INSERT INTO ", tbl, " VALUES",
-  " ('cost.geno.single', '", 1 / 50, "')"
+  " ('cost.geno.single', '", params$cost.geno.single, "')"
 ) # idem
 res <- dbExecute(conn = db, query)
 query <- paste0(
@@ -1561,7 +1583,7 @@ res <- dbExecute(conn = db, query)
 
 query <- paste0(
   "INSERT INTO ", tbl, " VALUES",
-  " ('initialBudget', '", cost.pheno.field * nb.plots * 10 * 1.3, "')"
+  " ('initialBudget', '", params$initialBudget * params$cost.pheno.field, "')"
 ) # idem
 res <- dbExecute(conn = db, query)
 ```

--- a/src/server/server_admin.R
+++ b/src/server/server_admin.R
@@ -673,6 +673,10 @@ gameInit_input_validator <- InputValidator$new()
 
 gameInit_seed <- gameInit_seed_server("gameInit_seed", gameInit_input_validator)
 
+gameInit_costs <- gameInit_costs_server("gameInit_costs", gameInit_input_validator)
+
+
+
 
 gameInit_input_validator$add_rule("initialisation_security_text", function(x) {
   if (is.null(x)) return(NULL)
@@ -751,7 +755,17 @@ observeEvent(input$initialiseGame, {
 
   params <- list(
     progressBar = progress_bar,
-    rng_seed = gameInit_seed$value()
+    rng_seed = gameInit_seed$value(),
+    cost.pheno.field = gameInit_costs$value()$cost.pheno.field,
+    cost.pheno.patho = gameInit_costs$value()$cost.pheno.patho,
+    cost.allof = gameInit_costs$value()$cost.allof,
+    cost.autof = gameInit_costs$value()$cost.autof,
+    cost.haplodiplo = gameInit_costs$value()$cost.haplodiplo,
+    cost.geno.hd = gameInit_costs$value()$cost.geno.hd,
+    cost.geno.ld = gameInit_costs$value()$cost.geno.ld,
+    cost.geno.single = gameInit_costs$value()$cost.geno.single,
+    cost.register = gameInit_costs$value()$cost.register,
+    initialBudget = gameInit_costs$value()$initialBudget
   )
 
   out_report <- rmarkdown::render("./src/plantbreedgame_setup.Rmd",

--- a/src/server/server_admin.R
+++ b/src/server/server_admin.R
@@ -648,7 +648,7 @@ output$admin_T1T2GameProgress <- renderPlotly({
 
 
 output$download_game_init_report <- downloadHandler(
-  filename = paste0("plantBreedGame_initialisation_report_", strftime(Sys.time(),format = "%Y-%M-%d"), ".html"), # lambda function
+  filename = paste0("plantBreedGame_initialisation_report_", strftime(Sys.time(),format = "%Y-%m-%d"), ".html"), # lambda function
   content = function(file) file.copy(GAME_INIT_REPORT, file),
   contentType = "text/html"
 )

--- a/src/server/server_admin.R
+++ b/src/server/server_admin.R
@@ -272,54 +272,74 @@ observeEvent(input$deleteSession, {
 
 ## Constant managment ----
 
-# 1. seed.year.effect:
 # get the current value
 output$admin_currentSYE <- renderText({
   input$admin_button_seedYearEfect # take depedency
-  yearEffectSeed <- getBreedingGameConstants()$seed.year.effect
-  yearEffectSeed
+  getBreedingGameConstants()$seed.year.effect
+})
+output$admin_current_initial_budget <- renderText({
+  input$admin_button_const_initialBudget # take depedency
+  game_constants <- getBreedingGameConstants()
+  game_constants$initialBudget / game_constants$cost.pheno.field
 })
 
 # update new value
 observeEvent(input$admin_button_seedYearEfect, {
   newSeed <- input$admin_seedYearEfect
 
-  # check input value (must be a numeric)
-  checkOK <- TRUE
-  if (is.na(newSeed)) checkOK <- FALSE
-
-  # update data base
-  checkDB <- 1
-  if (checkOK) {
+  error <- valid_rng_seed(newSeed)
+  if (is.null(error)) {
     query <- paste0(
       "UPDATE constants SET value = ",
       newSeed, " WHERE item=='seed.year.effect'"
     )
     db_execute_request(query)
-  }
 
-  # notification messages
-  if (checkOK & checkDB == 1) {
-    notifMessage <- paste("seed.year.effect updated.")
+    notifMessage <- paste("Year effect seed updated.")
     showNotification(notifMessage,
       duration = 2, closeButton = TRUE,
       type = "default"
     )
-  } else if (!checkOK) { # !checkOK
-    notifMessage <- paste("ERROR: Submitted value is not an integer.")
-    showNotification(notifMessage,
-      duration = 2, closeButton = TRUE,
-      type = "error"
-    )
-  } else { # checkOK & checkDB!=1
-    notifMessage <- paste("ERROR during SQL execution")
-    showNotification(notifMessage,
-      duration = 2, closeButton = TRUE,
-      type = "error"
-    )
+
+    return(NULL)
   }
+
+    notifMessage <- paste("ERROR:", error)
+    showNotification(notifMessage,
+      duration = 2, closeButton = TRUE,
+      type = "error"
+    )
+
 })
 
+observeEvent(input$admin_button_const_initialBudget, {
+
+  new_initial_budget <- input$admin_const_initialBudget * getBreedingGameConstants()$cost.pheno.field
+
+  error <- valid_positive_number(new_initial_budget)
+  if (is.null(error)) {
+    query <- paste0(
+      "UPDATE constants SET value = ",
+      new_initial_budget, " WHERE item=='initialBudget'"
+    )
+    db_execute_request(query)
+
+    notifMessage <- paste("Initial budget updated.")
+    showNotification(notifMessage,
+      duration = 2, closeButton = TRUE,
+      type = "default"
+    )
+
+    return(NULL)
+  }
+
+    notifMessage <- paste("ERROR:", seed_error)
+    showNotification(notifMessage,
+      duration = 2, closeButton = TRUE,
+      type = "error"
+    )
+
+})
 
 
 

--- a/src/server/server_admin.R
+++ b/src/server/server_admin.R
@@ -695,7 +695,7 @@ gameInit_seed <- gameInit_seed_server("gameInit_seed", gameInit_input_validator)
 
 gameInit_costs <- gameInit_costs_server("gameInit_costs", gameInit_input_validator)
 
-
+gameInit_traits <- gameInit_traits_server("gameInit_geno_pheno_simul", gameInit_input_validator)
 
 
 gameInit_input_validator$add_rule("initialisation_security_text", function(x) {

--- a/src/server/server_admin.R
+++ b/src/server/server_admin.R
@@ -776,6 +776,7 @@ observeEvent(input$initialiseGame, {
   params <- list(
     progressBar = progress_bar,
     rng_seed = gameInit_seed$value(),
+
     cost.pheno.field = gameInit_costs$value()$cost.pheno.field,
     cost.pheno.patho = gameInit_costs$value()$cost.pheno.patho,
     cost.allof = gameInit_costs$value()$cost.allof,
@@ -785,7 +786,20 @@ observeEvent(input$initialiseGame, {
     cost.geno.ld = gameInit_costs$value()$cost.geno.ld,
     cost.geno.single = gameInit_costs$value()$cost.geno.single,
     cost.register = gameInit_costs$value()$cost.register,
-    initialBudget = gameInit_costs$value()$initialBudget
+    initialBudget = gameInit_costs$value()$initialBudget,
+
+    t1_mu = gameInit_traits$value()$t1_mu,
+    t1_min = gameInit_traits$value()$t1_min,
+    t1_cv_g = gameInit_traits$value()$t1_cv_g,
+    t1_h2 = gameInit_traits$value()$t1_h2,
+
+    t2_mu = gameInit_traits$value()$t2_mu,
+    t2_min = gameInit_traits$value()$t2_min,
+    t2_cv_g = gameInit_traits$value()$t2_cv_g,
+    t2_h2 = gameInit_traits$value()$t2_h2,
+
+    prop_pleio = gameInit_traits$value()$prop_pleio,
+    cor_pleio = gameInit_traits$value()$cor_pleio
   )
 
   out_report <- rmarkdown::render("./src/plantbreedgame_setup.Rmd",

--- a/src/server/server_id.R
+++ b/src/server/server_id.R
@@ -196,8 +196,8 @@ budget <- reactive({
       expenses <- 0
     }
 
-    iniTialBuget <- constants$initialBudget
-    return(round(iniTialBuget - expenses, 2))
+    initialBuget <- constants$initialBudget
+    return(round(initialBuget - expenses, 2))
   }
 })
 

--- a/src/ui/ui_admin_loggedIn.R
+++ b/src/ui/ui_admin_loggedIn.R
@@ -193,7 +193,7 @@ if (gameInitialised()) {
 
   manage_constants_tab_content <- div(
     div(
-      id = "admin_seedYearEffect",
+      id = "admin_const_seedYearEffect",
       style = "margin: 0px 0px 40px 0px;",
 
       # input:
@@ -201,7 +201,7 @@ if (gameInitialised()) {
         id = "admin_div_numInput_seedYearEfect",
         style = "display: inline-block;
         vertical-align: top;",
-        numericInput("admin_seedYearEfect", "seed.year.effect",
+        numericInput("admin_seedYearEfect", "RNG Seed for year effect",
           value = 4321,
           min = 0,
           max = NA,
@@ -215,15 +215,47 @@ if (gameInitialised()) {
         style = "display: inline-block;
         vertical-align: top;
         padding-top: 25px", # button align with numInput
-        actionButton("admin_button_seedYearEfect", "update seed.year.effect")
+        actionButton("admin_button_seedYearEfect", "update year effect RNG seed")
       ),
 
       # current value:
       div(
         id = "admin_currentSYE",
-        "Current", code("seed.year.effect"), ":", textOutput("admin_currentSYE", container = span)
+        "Current", code("year effect RNG seed"), ":", textOutput("admin_currentSYE", container = span)
       )
-    ) # end div "admin_seedYearEffect"
+    ), # end div "admin_seedYearEffect"
+
+    div(
+      id = "admin_const_initialBudget",
+      style = "margin: 0px 0px 40px 0px;",
+
+      # input:
+      div(
+        id = "admin_div_numInput_initialBudget",
+        style = "display: inline-block;
+        vertical-align: top;",
+        numericInput("admin_const_initialBudget", "Initial budget (relative to phenotyping plot)",
+          value = constantsReactive()$initialBudget / constantsReactive()$cost.pheno.field,
+          min = 0,
+          max = NA,
+          step = 100
+        )
+      ),
+
+      div(
+        id = "admin_div_button_const_initialBudget",
+        style = "display: inline-block;
+        vertical-align: top;
+        padding-top: 25px", # button align with numInput
+        actionButton("admin_button_const_initialBudget", "update initial budget")
+      ),
+
+      # current value:
+      div(
+        id = "admin_current_initial_budget",
+        "Current", code("initial budget"), ":", textOutput("admin_current_initial_budget", container = span)
+      )
+    )
   )
 
   disk_usage_tab_content <- div(

--- a/src/ui/ui_admin_loggedIn.R
+++ b/src/ui/ui_admin_loggedIn.R
@@ -360,6 +360,10 @@ game_initialisation_tab_content <- div(
         tags$li(code("Tester"), "(this breeder do not have a password, you can leave the password field empty to connect)")
       )
     ),
+    div(
+      h3("Game Initialisation Parameters:"),
+      gameInit_seed_ui("gameInit_seed")
+    ),
     uiOutput("initialisation_button")
   )
 )

--- a/src/ui/ui_admin_loggedIn.R
+++ b/src/ui/ui_admin_loggedIn.R
@@ -26,7 +26,7 @@
 
 
 if (gameInitialised()) {
-  default_tab <- "Manage sessions"
+  default_tab <- "Game setup"
   manage_sessions_tab_content <- div(
     div(
       style = "margin-bottom:50px;",
@@ -308,7 +308,7 @@ if (gameInitialised()) {
   )
 
 
-  game_initialisation_report_part <- div(
+  game_setup_tab_content <- div(
     h2("Game initialisation report"),
 
     p("The game is initialised. You can download the related report that contains",
@@ -321,8 +321,8 @@ if (gameInitialised()) {
 
     tags$iframe(seamless = "seamless",
                 src = file.path("reports", basename(GAME_INIT_REPORT)),
-                height = 700,
-                width = "90%",
+                height = 900,
+                width = "95%",
                 id = "game_init_report")
   )
 
@@ -340,16 +340,13 @@ if (gameInitialised()) {
   manage_constants_tab_content <- game_not_initialised_msg
   disk_usage_tab_content <- game_not_initialised_msg
   game_progress_tab_content <- game_not_initialised_msg
-
-
-  game_initialisation_report_part <- div()
+  game_setup_tab_content <- game_not_initialised_msg
 }
 
 
 game_initialisation_tab_content <- div(
-  game_initialisation_report_part,
   div (
-    h2("Game (re)-initialisation"),
+    h1("Game Initialisation"),
     p("By pressing the button below, you can initialise the game."),
     p("Once the initialisation is completed (which takes about 2 minutes), the page will automatically reload and you will be able to connect and play the game."),
     div(
@@ -361,8 +358,8 @@ game_initialisation_tab_content <- div(
       )
     ),
     div(
-      h3("Game Initialisation Parameters:"),
-      gameInit_seed_ui("gameInit_seed")
+      h2("Game Initialisation Parameters:"),
+      gameInit_seed_ui("gameInit_seed"),
     ),
     uiOutput("initialisation_button")
   )
@@ -373,6 +370,10 @@ game_initialisation_tab_content <- div(
 list(
   shinydashboard::tabBox(
     width = 12, title = "Admin", id = "admin_tabset", side = "left", selected = default_tab,
+    tabPanel(
+      "Game setup",
+      game_setup_tab_content
+    ),
     tabPanel(
       "Manage sessions",
       manage_sessions_tab_content

--- a/src/ui/ui_admin_loggedIn.R
+++ b/src/ui/ui_admin_loggedIn.R
@@ -360,6 +360,7 @@ game_initialisation_tab_content <- div(
     div(
       h2("Game Initialisation Parameters:"),
       gameInit_seed_ui("gameInit_seed"),
+      gameInit_costs_ui("gameInit_costs")
     ),
     uiOutput("initialisation_button")
   )

--- a/src/ui/ui_admin_loggedIn.R
+++ b/src/ui/ui_admin_loggedIn.R
@@ -392,6 +392,7 @@ game_initialisation_tab_content <- div(
     div(
       h2("Game Initialisation Parameters:"),
       gameInit_seed_ui("gameInit_seed"),
+      gameInit_traits_ui("gameInit_geno_pheno_simul"),
       gameInit_costs_ui("gameInit_costs")
     ),
     uiOutput("initialisation_button")

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,19 +1,6 @@
 library(testthat)
 
 # load functions
-invisible(
-  sapply(FUN = source,
-         X = list.files("src/fun", pattern = ".R$", full.names = T))
-)
-
-# run tests
-# test_file("tests/testthat/test_0_dependencies.R",
-#           stop_on_failure = TRUE,
-#           stop_on_warning = FALSE)
-# test_file("tests/testthat/test_game_time.R",
-#           stop_on_failure = TRUE,
-#           stop_on_warning = FALSE)
-
 test_dir("tests/testthat",
          stop_on_failure = TRUE,
          stop_on_warning = FALSE)

--- a/tests/testthat/test_0_dependencies.R
+++ b/tests/testthat/test_0_dependencies.R
@@ -16,4 +16,5 @@ test_that("dependencies", {
   expect_no_error({library(shinyjs)})
   expect_no_error({library(shinyvalidate)})
   expect_no_error({library(vistime)})
+  expect_no_error({library(bsicons)})
 })

--- a/tests/testthat/test_0_dependencies.R
+++ b/tests/testthat/test_0_dependencies.R
@@ -14,5 +14,6 @@ test_that("dependencies", {
   expect_no_error({library(shinycssloaders)})
   expect_no_error({library(shinydashboard)})
   expect_no_error({library(shinyjs)})
+  expect_no_error({library(shinyvalidate)})
   expect_no_error({library(vistime)})
 })

--- a/tests/testthat/test_gameInit_validation.R
+++ b/tests/testthat/test_gameInit_validation.R
@@ -2,6 +2,9 @@
 library(testthat)
 source("../../src/fun/func_gameInit_validation.R", local = TRUE, encoding = "UTF-8")
 
+is_error <- function(x) {
+  expect_type(x, "character")
+}
 
 test_that("valid_rng_seed", {
 
@@ -10,14 +13,15 @@ test_that("valid_rng_seed", {
   expect_null(valid_rng_seed(NULL))
 
   # invalid cases (no error)
-  expect_type(valid_rng_seed(NA), "character")
-  expect_type(valid_rng_seed(24.234), "character")
-  expect_type(valid_rng_seed(-42), "character")
-  expect_type(valid_rng_seed("abc"), "character")
-  expect_type(valid_rng_seed(NULL, FALSE), "character")
+  is_error(valid_rng_seed(42.234))
+  is_error(valid_rng_seed(-42))
+
+  is_error(valid_rng_seed(NA))
+  is_error(valid_rng_seed("abc"))
+  is_error(valid_rng_seed(NULL, accept_null = FALSE))
 
   # invalid cases (error)
-  expect_error(valid_rng_seed(24.234, FALSE, TRUE))
+  expect_error(valid_rng_seed(24.234, raise_error = TRUE))
 
 })
 
@@ -31,13 +35,228 @@ test_that("valid_positive_number", {
   expect_null(valid_positive_number(NULL))
 
   # invalid cases (no error)
-  expect_type(valid_positive_number(NA), "character")
-  expect_type(valid_positive_number(-42), "character")
-  expect_error(valid_positive_number("24.234", FALSE, TRUE))
-  expect_type(valid_positive_number("abc"), "character")
-  expect_type(valid_positive_number(NULL, FALSE), "character")
+  is_error(valid_positive_number(-42))
+  is_error(valid_positive_number(0, strict = TRUE))
+
+  is_error(valid_positive_number(NA))
+  is_error(valid_positive_number("24.234"))
+  is_error(valid_positive_number("abc"))
+  is_error(valid_positive_number(NULL, accept_null = FALSE))
 
   # invalid cases (error)
-  expect_error(valid_positive_number("abc", FALSE, TRUE))
+  expect_error(valid_positive_number("abc", raise_error = TRUE))
+
+})
+
+test_that("valid_number", {
+
+  # OK cases
+  expect_null(valid_number(42))
+  expect_null(valid_number(42.42))
+  expect_null(valid_number(-42))
+  expect_null(valid_number(-42.42))
+  expect_null(valid_number(0))
+  expect_null(valid_number(NULL))
+
+  # invalid cases (no error)
+  is_error(valid_number(NA))
+  is_error(valid_number("24.234"))
+  is_error(valid_number("-24.234"))
+  is_error(valid_number("abc"))
+  is_error(valid_number(NULL, accept_null = FALSE))
+
+  # invalid cases (error)
+  expect_error(valid_number("abc", FALSE, raise_error = TRUE))
+
+})
+
+
+test_that("valid_range", {
+
+  # OK cases
+  expect_null(valid_range(42, 41, 43))
+  expect_null(valid_range(-42, -43, -41))
+  expect_null(valid_range(0, 0, 1))
+  expect_null(valid_range(1, 0, 1))
+  expect_null(valid_range(NULL))
+
+  # invalid cases (no error)
+  is_error(valid_range(42, 43, 44))
+  is_error(valid_range(-42, -44, -43))
+  is_error(valid_range(0, 0, 1, incl_min = FALSE))
+  is_error(valid_range(1, 0, 1, incl_max = FALSE))
+
+  is_error(valid_range(NA))
+  is_error(valid_range("abc"))
+  is_error(valid_range(NULL, accept_null = FALSE))
+
+  # invalid cases (error)
+  expect_error(valid_range("abc", FALSE, raise_error = TRUE))
+
+})
+
+
+
+test_that("valid_mu", {
+
+  # OK cases
+  expect_null(valid_mu(42))
+  expect_null(valid_mu(42.42))
+  expect_null(valid_mu(-42))
+  expect_null(valid_mu(-42.42))
+  expect_null(valid_mu(NULL))
+
+  # invalid cases (no error)
+  is_error(valid_mu(0))
+
+  is_error(valid_mu(NA))
+  is_error(valid_mu("24.234"))
+  is_error(valid_mu("-24.234"))
+  is_error(valid_mu("abc"))
+  is_error(valid_mu(NULL, accept_null = FALSE))
+
+  # invalid cases (error)
+  expect_error(valid_mu("abc", FALSE, raise_error = TRUE))
+
+})
+
+
+test_that("valid_Tmin", {
+
+  # OK cases
+  expect_null(valid_Tmin(42, 100))
+  expect_null(valid_Tmin(42.42, 100))
+  expect_null(valid_Tmin(-42, 100))
+  expect_null(valid_Tmin(-42.42, 100))
+  expect_null(valid_Tmin(NULL))
+
+  # invalid cases (no error)
+  is_error(valid_Tmin(42.42, 0))
+  is_error(valid_Tmin(-42, -100))
+
+  is_error(valid_Tmin(NA, 1))
+  is_error(valid_Tmin("24.234", 1))
+  is_error(valid_Tmin("-24.234", 1))
+  is_error(valid_Tmin("abc", 1))
+
+  is_error(valid_Tmin(NULL, 1, accept_null = FALSE))
+
+  # invalid cases (error)
+  expect_error(valid_Tmin(42.42, 0, FALSE, raise_error = TRUE))
+
+})
+
+
+test_that("valid_cv_g", {
+
+  # OK cases
+  expect_null(valid_cv_g(12))
+  expect_null(valid_cv_g(0.13))
+  expect_null(valid_cv_g(NULL))
+
+  # invalid cases (no error)
+  is_error(valid_cv_g(-24.234))
+  is_error(valid_cv_g(0))
+
+  is_error(valid_cv_g(NA))
+  is_error(valid_cv_g("24.234"))
+  is_error(valid_cv_g("-24.234"))
+  is_error(valid_cv_g("abc"))
+  is_error(valid_cv_g(NULL, accept_null = FALSE))
+
+  # invalid cases (error)
+  expect_error(valid_cv_g(-1, FALSE, raise_error = TRUE))
+
+})
+
+test_that("valid_h2", {
+
+  # OK cases
+  expect_null(valid_h2(0.3))
+  expect_null(valid_h2(NULL))
+
+  # invalid cases (no error)
+  is_error(valid_h2(0))
+  is_error(valid_h2(1))
+  is_error(valid_h2(1.1))
+  is_error(valid_h2(-0.1))
+
+  is_error(valid_h2(NA))
+  is_error(valid_h2("24.234"))
+  is_error(valid_h2("-24.234"))
+  is_error(valid_h2("abc"))
+  is_error(valid_h2(NULL, accept_null = FALSE))
+
+  # invalid cases (error)
+  expect_error(valid_h2(42, FALSE, raise_error = TRUE))
+
+})
+
+
+test_that("valid_variance", {
+
+  # OK cases
+  expect_null(valid_variance(0.3))
+  expect_null(valid_variance(100))
+  expect_null(valid_variance(NULL))
+  expect_null(valid_variance(NA, accept_na = TRUE))
+
+  # invalid cases (no error)
+  is_error(valid_variance(-0.1))
+  is_error(valid_variance(0))
+
+  is_error(valid_variance(NA))
+  is_error(valid_variance("24.234"))
+  is_error(valid_variance("-24.234"))
+  is_error(valid_variance("abc"))
+  is_error(valid_variance(NULL, accept_null = FALSE))
+
+  # invalid cases (error)
+  expect_error(valid_variance(-42, FALSE, raise_error = TRUE))
+
+})
+
+
+test_that("valid_prop_pleio", {
+
+  # OK cases
+  expect_null(valid_prop_pleio(0.7))
+  expect_null(valid_prop_pleio(NULL))
+
+  # invalid cases (no error)
+  is_error(valid_prop_pleio(-0.1))
+  is_error(valid_prop_pleio(1.2))
+
+  is_error(valid_prop_pleio(NA))
+  is_error(valid_prop_pleio("24.234"))
+  is_error(valid_prop_pleio("-24.234"))
+  is_error(valid_prop_pleio("abc"))
+  is_error(valid_prop_pleio(NULL, accept_null = FALSE))
+
+  # invalid cases (error)
+  expect_error(valid_prop_pleio(-42, FALSE, raise_error = TRUE))
+
+})
+
+
+test_that("valid_cor_pleio", {
+
+  # OK cases
+  expect_null(valid_cor_pleio(0.7))
+  expect_null(valid_cor_pleio(-0.3))
+  expect_null(valid_cor_pleio(NULL))
+
+  # invalid cases (no error)
+  is_error(valid_cor_pleio(-1.2))
+  is_error(valid_cor_pleio(1.1))
+
+  is_error(valid_cor_pleio(NA))
+  is_error(valid_cor_pleio("24.234"))
+  is_error(valid_cor_pleio("-24.234"))
+  is_error(valid_cor_pleio("abc"))
+  is_error(valid_cor_pleio(NULL, accept_null = FALSE))
+
+  # invalid cases (error)
+  expect_error(valid_cor_pleio(-42, FALSE, raise_error = TRUE))
 
 })

--- a/tests/testthat/test_gameInit_validation.R
+++ b/tests/testthat/test_gameInit_validation.R
@@ -20,3 +20,24 @@ test_that("valid_rng_seed", {
   expect_error(valid_rng_seed(24.234, FALSE, TRUE))
 
 })
+
+
+test_that("valid_positive_number", {
+
+  # OK cases
+  expect_null(valid_positive_number(42))
+  expect_null(valid_positive_number(42.42))
+  expect_null(valid_positive_number(0))
+  expect_null(valid_positive_number(NULL))
+
+  # invalid cases (no error)
+  expect_type(valid_positive_number(NA), "character")
+  expect_type(valid_positive_number(-42), "character")
+  expect_error(valid_positive_number("24.234", FALSE, TRUE))
+  expect_type(valid_positive_number("abc"), "character")
+  expect_type(valid_positive_number(NULL, FALSE), "character")
+
+  # invalid cases (error)
+  expect_error(valid_positive_number("abc", FALSE, TRUE))
+
+})

--- a/tests/testthat/test_gameInit_validation.R
+++ b/tests/testthat/test_gameInit_validation.R
@@ -1,0 +1,22 @@
+
+library(testthat)
+source("../../src/fun/func_gameInit_validation.R", local = TRUE, encoding = "UTF-8")
+
+
+test_that("valid_rng_seed", {
+
+  # OK cases
+  expect_null(valid_rng_seed(42))
+  expect_null(valid_rng_seed(NULL))
+
+  # invalid cases (no error)
+  expect_type(valid_rng_seed(NA), "character")
+  expect_type(valid_rng_seed(24.234), "character")
+  expect_type(valid_rng_seed(-42), "character")
+  expect_type(valid_rng_seed("abc"), "character")
+  expect_type(valid_rng_seed(NULL, FALSE), "character")
+
+  # invalid cases (error)
+  expect_error(valid_rng_seed(24.234, FALSE, TRUE))
+
+})

--- a/tests/testthat/test_game_time.R
+++ b/tests/testthat/test_game_time.R
@@ -1,4 +1,8 @@
 
+library(testthat)
+source("../../src/fun/func_time.R", local = TRUE, encoding = "UTF-8")
+
+
 firstYear = 2000
 game_first_day = strptime(paste0(firstYear, "-01-01 00:00"), format = "%Y-%m-%d %H:%M")
 

--- a/tools/installDeps.R
+++ b/tools/installDeps.R
@@ -20,7 +20,9 @@ install.packages(
     "shinyjs",
     "rmarkdown",
     "lubridate",
-    "vistime"
+    "vistime",
+    "shinyvalidate",
+    "bsicons"
   )
 )
 

--- a/www/style.css
+++ b/www/style.css
@@ -117,3 +117,12 @@ h6 {
   border-color: #00a65a;
   border-radius: 10px;
 }
+
+details > summary {
+  cursor: pointer;
+  display: list-item;
+}
+
+.has-error {
+  color: #dd4b39;
+}


### PR DESCRIPTION
This PR implements the ability to initialise the game with different parameters than the default ones.

The game initialisation script have a lot of parameters and not all of them have been implemented yet. This PR implements:

- The global RNG seed
- Costs related parameters (genotyping costs etc...)
- Phenotypic simulation parameters (heritability etc...)

To have a rather concise UI, each group of parameters are encapsulated in collapsible sections that extend when clicked:

![image](https://github.com/user-attachments/assets/fd65cdec-38e2-4393-ad13-3f6f796e171c)

The documentation about the role of each parameters is done by providing some general guidelines at the beginning of each section (once expanded), and by clicking on the labels of each parameter, for example (for the RNG seed):

![image](https://github.com/user-attachments/assets/8299388d-034a-4c82-8ac0-856cbb2c4bb0)
![image](https://github.com/user-attachments/assets/394d5e2a-16b3-4595-9571-e29c744ceefb)

Moreover, some information related to the current set of parameters are shown on the right hand side in order to help the user in their choices (cf. the section showing the implementation of each group of parameters below).

In order to avoid crashes of the game initialisation script as much as possible, each parameter is validated in real time by the application. In case some parameters are invalid, they will appears in red along with a feedback message explaining what is wrong.

![image](https://github.com/user-attachments/assets/a3b9bf7f-c772-4214-a9f3-5aed3073ee8e)

If any parameters is invalid, it will be impossible for the user to trigger the game initialisation (the button is automatically disabled)

## Cost related parameters:

![image](https://github.com/user-attachments/assets/b7ffe07b-78a5-4cec-8141-d66eb3badc8b)

The right part show a summary of the provided cost in terms of "phenotyping plot" and in "Mendels" (the game's money).

## Phenotyping simulation parameters:

![image](https://github.com/user-attachments/assets/a85a271f-cdc8-463c-b8a4-47bc3aa8d7f4)

The right part show the values of different variances of the generative model calculated with the current set of inputs.
Along with 2 box plots (one for each trait) that show what the phenotype of the initial population can look like. (similar to one of the plot in section "7.7 Simulate traits 1 and 2" of the setup report).  
These values are quickly generated by the application following the current parameters but do not correspond to what will be actually generated by the initialisation script (as mentioned below the plots).

One important things to keep in mind is the game initialisation script is rather complex and it is possible to have a set of apparently "valid" parameters (eg. heritability is between 0 and 1 etc...) that leads to invalid "simulations parameters" (ie. other values calculated by the initialisation script and used for the simulation, for example the variances of the generative model in this case).  

![image](https://github.com/user-attachments/assets/7df308b8-ea6c-4867-936a-9b99f7190d19)

Here, I check that all those variances are acceptable (ie. stictly positive). Those that are not appears in red and the initialisation can not be triggered.
 



