### PR TITLE
Data visualisation

### DIFF
--- a/global.R
+++ b/global.R
@@ -29,6 +29,7 @@ source("./src/fun/module_breederList.R", local = TRUE, encoding = "UTF-8")
 source("./src/fun/func_dbRequests.R", local = TRUE, encoding = "UTF-8")
 source("./src/fun/module_gameInit_params.R", local = TRUE, encoding = "UTF-8")
 source("./src/fun/func_gameInit_validation.R", local = TRUE, encoding = "UTF-8")
+source("./src/fun/func_ui_util.R", local = TRUE, encoding = "UTF-8")
 
 ## -------------------------------------------------------------------
 ## parameters

--- a/server.R
+++ b/server.R
@@ -59,6 +59,7 @@ shinyServer(function(input, output, session) {
   source("src/server/server_plant_material.R", local = TRUE, encoding = "UTF-8")$value
   source("src/server/server_pheno.R", local = TRUE, encoding = "UTF-8")$value
   source("src/server/server_geno.R", local = TRUE, encoding = "UTF-8")$value
+  source("src/server/server_data_viz.R", local = TRUE, encoding = "UTF-8")$value
   source("src/server/server_eval.R", local = TRUE, encoding = "UTF-8")$value
   source("src/server/server_theory.R", local = TRUE, encoding = "UTF-8")$value
   source("src/server/server_admin.R", local = TRUE, encoding = "UTF-8")$value

--- a/src/fun/func_data-viz.R
+++ b/src/fun/func_data-viz.R
@@ -1,0 +1,298 @@
+none_value <- "-- None --"
+
+data_viz_ui <- function(id) {
+  ns <- NS(id)
+  div(
+    div(
+      selectInput(ns("x_var"),
+        "X variable",
+        choices = list(none_value),
+        multiple = FALSE
+      ),
+      selectInput(ns("y_var"),
+        "Y variable",
+        choices = list(none_value),
+        multiple = FALSE
+      ),
+      selectInput(ns("col_var"),
+        "Color variable",
+        choices = list(none_value),
+        multiple = FALSE
+      )
+    ),
+    div(
+      plotlyOutput(ns("plot"))
+    )
+  )
+}
+
+data_viz_server <- function(id, plot_data) {
+  moduleServer(id, function(input, output, session) {
+
+    observe({
+      data <- plot_data()
+      if (is.null(data)) {
+        updateSelectInput(session, "x_var",
+          choices = none_value,
+        )
+        updateSelectInput(session, "y_var",
+          choices = none_value,
+        )
+        updateSelectInput(session, "col_var",
+          choices = none_value,
+        )
+        return(NULL)
+      }
+
+      var_list <- colnames(data)
+      var_list <- c(none_value, var_list)
+      updateSelectInput(session, "x_var",
+        choices = var_list,
+        selected = ifelse(!is_null_var(input$x_var) && input$x_var %in% var_list, input$x_var, var_list[2])
+      )
+      updateSelectInput(session, "y_var",
+        choices = var_list,
+        selected = ifelse(!is_null_var(input$x_var) && input$y_var %in% var_list, input$y_var, var_list[1])
+      )
+      updateSelectInput(session, "col_var",
+        choices = var_list,
+        selected = ifelse(!is_null_var(input$x_var) && input$col_var %in% var_list, input$col_var, var_list[1])
+      )
+    })
+
+    output$plot <- renderPlotly({
+      data <- plot_data()
+      if ((input$x_var == none_value && input$y_var == none_value) || is.null(data)) {
+        return(empty_plot("No data to show"))
+      }
+
+      if (input$x_var == none_value || input$y_var == none_value) {
+        return(
+          plot_1D(
+            data = data,
+            x_var = input$x_var,
+            y_var = input$y_var,
+            col_var = input$col_var
+          )
+        )
+      }
+
+      return(
+        plot_2D(
+          data = data,
+          x_var = input$x_var,
+          y_var = input$y_var,
+          col_var = input$col_var
+        )
+      )
+    })
+  })
+}
+
+empty_plot <- function(info = "") {
+  return(plot_ly(type = "scatter", mode = "markers") %>%
+    add_annotations(
+      x=0.5, y=0.5, xref = "paper", yref = "paper",
+      text = info,
+      xanchor = 'center',
+      showarrow = FALSE
+    ))
+}
+
+plot_1D <- function(data, x_var, y_var, col_var) {
+  var_of_interest <- c(x_var, y_var)[ which(!is_null_var(c(x_var, y_var))) ]
+
+  if (is.numeric(data[, var_of_interest])) {
+    return(histogram(data, x_var, y_var, col_var))
+  }
+  barplot(data, x_var, y_var, col_var)
+}
+
+plot_2D <- function(data, x_var, y_var, col_var) {
+  if (is.numeric(data[, x_var]) && is.numeric(data[, y_var])) {
+    return(scatter_plot(data, x_var, y_var, col_var))
+  }
+  if (any(c(is.numeric(data[, x_var]), is.numeric(data[, y_var])))) {
+    return(box_plot(data, x_var, y_var, col_var))
+  }
+  empty_plot("Plot for two categorical variables is not implemented.\nYou could rather use one variable as X axis and the other as color.")
+}
+
+scatter_plot <- function(data, x_var, y_var, col_var) {
+  color <- NULL
+  if (!is_null_var(col_var)) {
+    color <- data[, col_var]
+  }
+  p <- plot_ly(type = "scatter",
+               mode = "markers",
+               data = data,
+               x = data[, x_var],
+               y = data[, y_var],
+               color = color,
+               hoverinfo = "text",
+               text = apply(data, 1, function(l) {
+                 paste(names(l), ":", l, collapse = "\n")
+               }))
+  p <- layout(p,
+              yaxis = list(title = y_var),
+              xaxis = list(title = x_var),
+              legend = list(title = list(text = col_var))
+              )
+  p
+}
+
+box_plot <- function(data, x_var, y_var, col_var) {
+  color <- NULL
+  if (!is_null_var(col_var)) {
+    color <- data[, col_var]
+  }
+  x_values <- NULL
+  if (!is_null_var(x_var)) {
+    x_values <- data[, x_var]
+  }
+  y_values <- NULL
+  if (!is_null_var(y_var)) {
+    y_values <- data[, y_var]
+  }
+
+  p <- plot_ly(
+    type = "box",
+    data = data,
+    y = y_values,
+    x = x_values,
+    color = color,
+    boxpoints = "all",
+    jitter = 0.3,
+    pointpos = 0,
+    hoverinfo = "text",
+    text = apply(data, 1, function(l) {
+      paste(names(l), ":", l, collapse = "\n")
+    })
+  )
+  p <- layout(p,
+              boxmode = "group",
+              yaxis = list(title = y_var),
+              xaxis = list(title = x_var),
+              legend = list(title = list(text = col_var))
+              )
+  p
+}
+
+histogram <- function(data, x_var, y_var, col_var) {
+  hist_axis_title <- "Number of observations"
+  data_list <- list(data)
+
+  alpha <- 1
+  if (!is_null_var(col_var)) {
+    data_list <- split(data, data[, col_var])
+    alpha <- 0.6
+  }
+
+  x_values <- NULL
+  x_axis_title <- hist_axis_title
+  if (!is_null_var(x_var)) {
+    x_axis_title <- x_var
+  }
+
+  y_values <- NULL
+  y_axis_title <- hist_axis_title
+  if (!is_null_var(y_var)) {
+    y_axis_title <- y_var
+  }
+
+  p <- plot_ly(
+    type = "histogram",
+    alpha = alpha
+  )
+  for (data_index in seq_along(data_list)) {
+    data <- data_list[[data_index]]
+    x_values <- NULL
+    if (!is_null_var(x_var)) {
+      x_values <- data[, x_var]
+    }
+    y_values <- NULL
+    if (!is_null_var(y_var)) {
+      y_values <- data[, y_var]
+    }
+    p <- add_histogram(
+      p,
+      data = data,
+      y = y_values,
+      x = x_values,
+      name = names(data_list)[data_index],
+      marker = list(
+        line = list(color = 'rgb(235, 237, 235)', width = 1)
+      )
+    )
+  }
+
+  p <- layout(
+    p,
+    barmode = "overlay",
+    showlegend = !is_null_var(col_var),
+    yaxis = list(title = y_axis_title),
+    xaxis = list(title = x_axis_title),
+    legend = list(title = list(text = col_var))
+  )
+  p
+}
+
+
+barplot <- function(data, x_var, y_var, col_var) {
+  hist_axis_title <- "Number of observations"
+
+  data <- data %>%
+    dplyr::mutate_if(is.character, as.factor)
+
+  if (!is_null_var(col_var)) {
+    data <- dplyr::group_by(data, !!sym(col_var), .drop = FALSE)
+  }
+
+  x_axis_title <- hist_axis_title
+  if (!is_null_var(x_var)) {
+    data <- dplyr::group_by(data, !!sym(x_var), .add = TRUE, .drop = FALSE)
+    x_axis_title <- x_var
+  }
+
+  y_axis_title <- hist_axis_title
+  if (!is_null_var(y_var)) {
+    data <- dplyr::group_by(data, !!sym(y_var), .add = TRUE, .drop = FALSE)
+    y_axis_title <- y_var
+  }
+
+  plt_data <- as.data.frame(dplyr::summarise(data, n = dplyr::n(), .groups = "drop"), stringsAsFactors = FALSE)
+
+  if (!is_null_var(x_var)) {
+    x_values <- plt_data[[x_var]]
+    y_values <- plt_data[["n"]]
+  } else {
+    x_values <- plt_data[["n"]]
+    y_values <- plt_data[[y_var]]
+  }
+
+  col_values <- NULL
+  if (!is_null_var(col_var)) {
+    col_values <- plt_data[[col_var]]
+  }
+
+  p <- plot_ly(plt_data,
+               x = x_values,
+               y = y_values,
+               color = col_values,
+               type = 'bar')
+
+  p <- layout(
+    p,
+    showlegend = !is_null_var(col_var),
+    yaxis = list(title = y_axis_title),
+    xaxis = list(title = x_axis_title),
+    barmode = 'stack',
+    legend = list(title = list(text = col_var))
+  )
+  p
+}
+
+is_null_var <- function(vars) {
+  sapply(vars, function(var) { identical(var, none_value) })
+}
+

--- a/src/fun/func_data-viz.R
+++ b/src/fun/func_data-viz.R
@@ -3,26 +3,30 @@ none_value <- "-- None --"
 data_viz_ui <- function(id) {
   ns <- NS(id)
   div(
-    div(
-      selectInput(ns("x_var"),
-        "X variable",
-        choices = list(none_value),
-        multiple = FALSE
+    div(style = "display: flex;",
+      div(style = "flex: 0;",
+        selectInput(ns("x_var"),
+          "X variable",
+          choices = list(none_value),
+          multiple = FALSE
+        ),
+
+        selectInput(ns("y_var"),
+          "Y variable",
+          choices = list(none_value),
+          multiple = FALSE
+        ),
+        selectInput(ns("col_var"),
+          "Color variable",
+          choices = list(none_value),
+          multiple = FALSE
+        )
       ),
-      selectInput(ns("y_var"),
-        "Y variable",
-        choices = list(none_value),
-        multiple = FALSE
-      ),
-      selectInput(ns("col_var"),
-        "Color variable",
-        choices = list(none_value),
-        multiple = FALSE
+      div(style = "flex: 1;",
+        plotlyOutput(ns("plot"))
       )
     ),
-    div(
-      plotlyOutput(ns("plot"))
-    ),
+    hr(),
     div(style = "margin-top: 30px;",
       dataTableOutput(ns("dataTable"))
     )
@@ -91,13 +95,19 @@ data_viz_server <- function(id, plot_data) {
     })
 
     output$dataTable <- renderDataTable({
-      DT::datatable(plot_data(),
-        filter = "top",
+      data <- plot_data()
+      filter <- "top"
+      if (is.null(data)) {
+        data <- data.frame(`Variable` = numeric())
+        filter <- "none"
+      }
+      DT::datatable(data,
+        filter = filter,
         style = "bootstrap4",
         options = list(
-          pageLength = 20,
-          lengthMenu = c(10, 20, 50, 100),
-          sDom = '<"top"f>rt<"bottom"lp><"clear">'
+          language = list(emptyTable = 'Empty'),
+          pageLength = 10,
+          lengthMenu = c(10, 25, 50, 100)
         )
       )
     })

--- a/src/fun/func_data-viz.R
+++ b/src/fun/func_data-viz.R
@@ -55,18 +55,19 @@ data_viz_server <- function(id, plot_data) {
       }
 
       var_list <- colnames(data)
+      # browser()
       var_list <- c(none_value, var_list)
       updateSelectInput(session, "x_var",
         choices = var_list,
-        selected = ifelse(!is_null_var(input$x_var) && input$x_var %in% var_list, input$x_var, var_list[2])
+        selected = ifelse(input$x_var %in% var_list, input$x_var, none_value)
       )
       updateSelectInput(session, "y_var",
         choices = var_list,
-        selected = ifelse(!is_null_var(input$x_var) && input$y_var %in% var_list, input$y_var, var_list[1])
+        selected = ifelse(input$y_var %in% var_list, input$y_var, none_value)
       )
       updateSelectInput(session, "col_var",
         choices = var_list,
-        selected = ifelse(!is_null_var(input$x_var) && input$col_var %in% var_list, input$col_var, var_list[1])
+        selected = ifelse(input$col_var %in% var_list, input$col_var, none_value)
       )
     })
 

--- a/src/fun/func_data-viz.R
+++ b/src/fun/func_data-viz.R
@@ -371,6 +371,7 @@ plot_warning <- function(data, x_var, y_var, col_var) {
           warnings_messages <- c(warnings_messages,
             "Categorical variable with a large amount of levels is detected, plot may not render correctly."
           )
+          break()
         }
       }
     }

--- a/src/fun/func_data-viz.R
+++ b/src/fun/func_data-viz.R
@@ -22,6 +22,9 @@ data_viz_ui <- function(id) {
     ),
     div(
       plotlyOutput(ns("plot"))
+    ),
+    div(style = "margin-top: 30px;",
+      dataTableOutput(ns("dataTable"))
     )
   )
 }
@@ -83,6 +86,18 @@ data_viz_server <- function(id, plot_data) {
           x_var = input$x_var,
           y_var = input$y_var,
           col_var = input$col_var
+        )
+      )
+    })
+
+    output$dataTable <- renderDataTable({
+      DT::datatable(plot_data(),
+        filter = "top",
+        style = "bootstrap4",
+        options = list(
+          pageLength = 20,
+          lengthMenu = c(10, 20, 50, 100),
+          sDom = '<"top"f>rt<"bottom"lp><"clear">'
         )
       )
     })

--- a/src/fun/func_data-viz.R
+++ b/src/fun/func_data-viz.R
@@ -31,6 +31,7 @@ data_viz_ui <- function(id) {
     ),
     hr(),
     div(style = "margin-top: 30px;",
+      id = ns("data-table"),
       withSpinner(dataTableOutput(ns("dataTable")))
     )
   )

--- a/src/fun/func_data-viz.R
+++ b/src/fun/func_data-viz.R
@@ -23,12 +23,12 @@ data_viz_ui <- function(id) {
         )
       ),
       div(style = "flex: 1;",
-        plotlyOutput(ns("plot"))
+        withSpinner(plotlyOutput(ns("plot")))
       )
     ),
     hr(),
     div(style = "margin-top: 30px;",
-      dataTableOutput(ns("dataTable"))
+      withSpinner(dataTableOutput(ns("dataTable")))
     )
   )
 }

--- a/src/fun/func_ui_util.R
+++ b/src/fun/func_ui_util.R
@@ -1,0 +1,26 @@
+
+tooltip_label <- function(label, description){
+
+  tooltip <- tags$details(
+    tags$summary(style = "cursor: pointer;",
+     label, bsicons::bs_icon("question-circle")
+    ),
+    tags$blockquote(style = "font-weight: normal; font-size: inherit; font-style: italic;",
+      description
+    )
+  )
+}
+
+collapible_section <- function(title, title_id, content) {
+
+  tags$details(style = "margin-top: 30px;",
+    tags$summary(
+      h3(title, "(click to expand)",
+         style = "margin-top: 0px; display: inline-block;",
+         id = title_id
+      )
+    ),
+    content
+  )
+
+}

--- a/src/fun/module_gameInit_params.R
+++ b/src/fun/module_gameInit_params.R
@@ -14,31 +14,6 @@ library(shinyvalidate)
 library(shiny)
 library(plotly)
 
-tooltip_label <- function(label, description){
-
-  tooltip <- tags$details(
-    tags$summary(style = "cursor: pointer;",
-     label, bsicons::bs_icon("question-circle")
-    ),
-    tags$blockquote(style = "font-weight: normal; font-size: inherit; font-style: italic;",
-      description
-    )
-  )
-}
-
-collapible_section <- function(title, title_id, content) {
-
-  tags$details(style = "margin-top: 30px;",
-    tags$summary(
-      h3(title, "(click to expand)",
-         style = "margin-top: 0px; display: inline-block;",
-         id = title_id
-      )
-    ),
-    content
-  )
-
-}
 
 gameInit_seed_ui <- function(id) {
   ns <- NS(id)

--- a/src/server/server_data_viz.R
+++ b/src/server/server_data_viz.R
@@ -99,22 +99,22 @@ observeEvent(input$categ_variables, {
   data <- req(raw_data_from_file())
   categ_var <- input$categ_variables
   quant_var <- colnames(data)[!colnames(data) %in% categ_var]
-  if (!setequal(quant_var, input$quant_variables)) {
-    updateSelectInput(session, "quant_variables",
-      selected = quant_var
-    )
-  }
-
+  updateSelectInput(session, "quant_variables",
+    selected = quant_var
+  )
 })
 
 
 data_from_file <- reactive({
 
   data <- raw_data_from_file()
-  for (var in input$quant_variables) {
+  categ_vars <- input$categ_variables
+  quant_vars <- colnames(data)[!colnames(data) %in% categ_vars]
+
+  for (var in quant_vars) {
     data[, var] <- as.numeric(data[, var])
   }
-  for (var in input$categ_variables) {
+  for (var in categ_vars) {
     data[, var] <- as.character(data[, var])
   }
   data

--- a/src/server/server_data_viz.R
+++ b/src/server/server_data_viz.R
@@ -46,6 +46,25 @@ output$data_viz_UI <- renderUI({
 })
 
 
+data_viz_file_validator <- InputValidator$new()
+data_viz_file_validator$add_rule("categ_variables", function(x) {
+  data <- raw_data_from_file()
+  must_be_categorical_var <- colnames(data)[sapply(colnames(data), function(var) {
+    numeric_values <- as.numeric(data[, var])
+    any(is.na(numeric_values))
+  })]
+  if (!all(must_be_categorical_var %in% x)) {
+    missing_var <- must_be_categorical_var[!must_be_categorical_var %in% x]
+    return(paste0(
+      "`", paste0(missing_var, collapse = "`, `"),
+      "`, must be categorical"
+      )
+    )
+  }
+  return(NULL)
+})
+data_viz_file_validator$enable()
+
 raw_data_from_file <- reactive({
   if (is.null(input$file_data_viz)) {
     return(NULL)

--- a/src/server/server_data_viz.R
+++ b/src/server/server_data_viz.R
@@ -1,0 +1,124 @@
+## Copyright 2015,2016,2017,2018,2019 Institut National de la Recherche Agronomique
+## and Montpellier SupAgro.
+##
+## This file is part of PlantBreedGame.
+##
+## PlantBreedGame is free software: you can redistribute it and/or modify
+## it under the terms of the GNU Affero General Public License as
+## published by the Free Software Foundation, either version 3 of the
+## License, or (at your option) any later version.
+##
+## PlantBreedGame is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU Affero General Public
+## License along with PlantBreedGame.  If not, see
+## <http://www.gnu.org/licenses/>.
+
+
+## Function
+source("src/fun/func_data-viz.R", local = TRUE, encoding = "UTF-8")
+
+
+
+###### server for "genotyping" ######
+
+## Main UI ----
+output$data_viz_UI <- renderUI({
+  if (!gameInitialised()) {
+    return(
+      source("src/ui/ui_gameNotInitialised.R", local = TRUE, encoding = "UTF-8")$value
+    )
+  }
+
+  if (breeder() != "No Identification" & breederStatus() != "player") {
+    return(source("src/ui/ui_data-viz_loggedIn.R", local = TRUE, encoding = "UTF-8")$value)
+  }
+
+  return(
+    shinydashboard::box(
+      width = 12, title = "Content unavailable",
+      div(p("Sorry, you need the 'game-master' status or the 'tester' status to access this."))
+    )
+  )
+})
+
+
+raw_data_from_file <- reactive({
+  if (is.null(input$file_data_viz)) {
+    return(NULL)
+  }
+
+  df <- utils::read.table(
+    input$file_data_viz$datapath,
+    header = TRUE,
+    sep = "\t",
+    stringsAsFactors = FALSE
+  )
+
+  can_be_numeric_var <- sapply(colnames(df), function(var) {
+    numeric_values <- as.numeric(df[, var])
+    !any(is.na(numeric_values))
+  })
+  numeric_var <- colnames(df)[can_be_numeric_var]
+  categ_var <- colnames(df)[!can_be_numeric_var]
+
+  updateSelectInput(session, "quant_variables",
+    choices = numeric_var,
+    selected = numeric_var
+  )
+  updateSelectInput(session, "categ_variables",
+    choices = colnames(df),
+    selected = categ_var
+  )
+  shinyjs::disable("quant_variables")
+  df
+})
+
+# observeEvent(input$quant_variables, {
+#   # TODO: This part is not greate the observed is called 2 times which is not greate
+#   if (is.null(input$quant_variables)) {
+#     return(NULL)
+#   }
+#   data <- req(raw_data_from_file())
+#   quant_var <- input$quant_variables
+#   categ_var <- colnames(data)[!colnames(data) %in% quant_var]
+#   if (!setequal(categ_var, input$categ_variables)) {
+#     updateSelectInput(session, "categ_variables",
+#       selected = categ_var
+#     )
+#   }
+# })
+
+observeEvent(input$categ_variables, {
+  if (is.null(input$categ_variables)) {
+    return(NULL)
+  }
+  data <- req(raw_data_from_file())
+  categ_var <- input$categ_variables
+  quant_var <- colnames(data)[!colnames(data) %in% categ_var]
+  if (!setequal(quant_var, input$quant_variables)) {
+    updateSelectInput(session, "quant_variables",
+      selected = quant_var
+    )
+  }
+
+})
+
+
+data_from_file <- reactive({
+
+  data <- raw_data_from_file()
+  for (var in input$quant_variables) {
+    data[, var] <- as.numeric(data[, var])
+  }
+  for (var in input$categ_variables) {
+    data[, var] <- as.character(data[, var])
+  }
+  data
+})
+
+data_viz_server("data-viz_file", data_from_file)
+

--- a/src/ui/ui_data-viz_loggedIn.R
+++ b/src/ui/ui_data-viz_loggedIn.R
@@ -27,9 +27,19 @@ list(
         h4("Import file"),
         fileInput(
           inputId = "file_data_viz",
-          label = NULL,
+          label = tooltip_label(
+            "Help about file format",
+            div(
+              p("Accepted format is the", strong("same as the phenotype data"), "provided by this game:"),
+              tags$ul(
+                tags$li("A", code(".txt"), "or", code(".tsv"), "file (or their gzip compression)"),
+                tags$li("Field separator must be", strong("a tabulation")),
+                tags$li("File must be encoded in UTF-8")
+              )
+            )
+          ),
           multiple = FALSE,
-          accept = c(".txt", ".tsv", ".txt.gz"),
+          accept = c(".txt", ".tsv", ".txt.gz", ".tsv.gz"),
           width = "100%"
         ),
         div(style = "display: inline-block; vertical-align: top; margin-right: 10px;",

--- a/src/ui/ui_data-viz_loggedIn.R
+++ b/src/ui/ui_data-viz_loggedIn.R
@@ -23,24 +23,30 @@ list(
     width = 12, title = "Data Visualisation", id = "data-viz", side = "left", selected = "From file",
     tabPanel(
       "From file",
-      div(
+      div(style = "",
         h4("Import file"),
         fileInput(
           inputId = "file_data_viz",
           label = NULL,
           multiple = FALSE,
-          accept = c(".txt", ".tsv", ".txt.gz")
+          accept = c(".txt", ".tsv", ".txt.gz"),
+          width = "100%"
         ),
-        selectInput("quant_variables",
-          "Quantitative variables",
-          choices = list("None","var 1", "var 2", "var 3"),
-          multiple = TRUE
+        div(style = "display: inline-block; vertical-align: top; margin-right: 10px;",
+          selectInput("categ_variables",
+            "Categorical variables",
+            choices = list("var 1", "var 2", "var 3"),
+            multiple = TRUE
+          )
         ),
-        selectInput("categ_variables",
-          "Categorical variables",
-          choices = list("var 1", "var 2", "var 3"),
-          multiple = TRUE
-        )
+        div(style = "display: inline-block; vertical-align: top;",
+          selectInput("quant_variables",
+            "Quantitative variables",
+            choices = list("None","var 1", "var 2", "var 3"),
+            multiple = TRUE
+          )
+        ),
+        hr()
       ),
       div(
         data_viz_ui("data-viz_file")

--- a/src/ui/ui_data-viz_loggedIn.R
+++ b/src/ui/ui_data-viz_loggedIn.R
@@ -1,0 +1,50 @@
+## Copyright 2015,2016,2017,2018,2019 Institut National de la Recherche Agronomique
+## and Montpellier SupAgro.
+##
+## This file is part of PlantBreedGame.
+##
+## PlantBreedGame is free software: you can redistribute it and/or modify
+## it under the terms of the GNU Affero General Public License as
+## published by the Free Software Foundation, either version 3 of the
+## License, or (at your option) any later version.
+##
+## PlantBreedGame is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU Affero General Public
+## License along with PlantBreedGame.  If not, see
+## <http://www.gnu.org/licenses/>.
+library(shiny)
+
+list(
+  shinydashboard::tabBox(
+    width = 12, title = "Data Visualisation", id = "data-viz", side = "left", selected = "From file",
+    tabPanel(
+      "From file",
+      div(
+        h4("Import file"),
+        fileInput(
+          inputId = "file_data_viz",
+          label = NULL,
+          multiple = FALSE,
+          accept = c(".txt", ".tsv", ".txt.gz")
+        ),
+        selectInput("quant_variables",
+          "Quantitative variables",
+          choices = list("None","var 1", "var 2", "var 3"),
+          multiple = TRUE
+        ),
+        selectInput("categ_variables",
+          "Categorical variables",
+          choices = list("var 1", "var 2", "var 3"),
+          multiple = TRUE
+        )
+      ),
+      div(
+        data_viz_ui("data-viz_file")
+      )
+    )
+  )
+)

--- a/src/ui/ui_data-viz_loggedIn.R
+++ b/src/ui/ui_data-viz_loggedIn.R
@@ -44,15 +44,28 @@ list(
         ),
         div(style = "display: inline-block; vertical-align: top; margin-right: 10px;",
           selectInput("categ_variables",
-            "Categorical variables",
-            choices = list("var 1", "var 2", "var 3"),
+            label = tooltip_label(
+              "Categorical variables",
+              div(
+                p("Select here the categorical variables of your data-set.")
+              )
+            ),
+            choices = list(),
             multiple = TRUE
           )
         ),
         div(style = "display: inline-block; vertical-align: top;",
           selectInput("quant_variables",
-            "Quantitative variables",
-            choices = list("None","var 1", "var 2", "var 3"),
+            label = tooltip_label(
+              "Quantitative variables",
+              div(
+                p("This input is disable, any variable that is not",
+                  "categorical is considered quantitative.",
+                  "Please remove categorical variables to mark them as",
+                  "quantitative.")
+              )
+            ),
+            choices = list(),
             multiple = TRUE
           )
         ),

--- a/tests_UI/test-1.spec.ts
+++ b/tests_UI/test-1.spec.ts
@@ -275,10 +275,16 @@ async function requestPlantMaterial(
     .getByRole("textbox", { name: "Browse..." })
     .setInputFiles("./tests/requestExamples/" + reqFile);
 
-  await page.getByRole("link", { name: "Check" }).click();
+  await page
+    .locator("#cross_tabset")
+    .getByRole("link", { name: "Check" })
+    .click();
   await expect(page.locator("#plmatUploaded")).toContainText("GOOD");
 
-  await page.getByRole("link", { name: "Summary" }).click();
+  await page
+    .locator("#cross_tabset")
+    .getByRole("link", { name: "Summary" })
+    .click();
   await expect(
     page.locator("#PltmatInvoice").getByRole("cell", { name: "Task" }),
   ).toBeVisible();
@@ -292,7 +298,10 @@ async function requestPlantMaterial(
     page.locator("#PltmatInvoice").locator("th").filter({ hasText: "Total" }),
   ).toBeVisible();
 
-  await page.getByRole("link", { name: "Data" }).click();
+  await page
+    .locator("#cross_tabset")
+    .getByRole("link", { name: "Data" })
+    .click();
   await expect(
     page
       .locator("#qryPlmat")
@@ -314,7 +323,10 @@ async function requestPlantMaterial(
       .getByLabel("explanations: activate to sort column ascending"),
   ).toBeVisible();
 
-  await page.getByRole("link", { name: "Request", exact: true }).click();
+  await page
+    .locator("#cross_tabset")
+    .getByRole("link", { name: "Request", exact: true })
+    .click();
   await expect(page.getByRole("button", { name: "Yes, I do!" })).toBeEnabled();
   await page.getByRole("button", { name: "Yes, I do!" }).click();
   await expect(page.getByText("Create Plant Material: Done !")).toBeVisible({
@@ -355,10 +367,16 @@ async function requestPhenotyping(
     .getByRole("textbox", { name: "Browse..." })
     .setInputFiles("./tests/requestExamples/" + reqFile);
 
-  await page.getByRole("link", { name: "Check" }).click();
+  await page
+    .locator("#pheno_tabset")
+    .getByRole("link", { name: "Check" })
+    .click();
   await expect(page.locator("#PhenoUploaded")).toContainText("GOOD");
 
-  await page.getByRole("link", { name: "Summary" }).click();
+  await page
+    .locator("#pheno_tabset")
+    .getByRole("link", { name: "Summary" })
+    .click();
   await expect(
     page.locator("#PhenoInvoice").getByRole("cell", { name: "Task" }),
   ).toBeVisible();
@@ -372,7 +390,10 @@ async function requestPhenotyping(
     page.locator("#PhenoInvoice").locator("th").filter({ hasText: "Total" }),
   ).toBeVisible();
 
-  await page.getByRole("link", { name: "Data" }).click();
+  await page
+    .locator("#pheno_tabset")
+    .getByRole("link", { name: "Data" })
+    .click();
   await expect(
     page
       .locator("#qryPheno")
@@ -389,7 +410,10 @@ async function requestPhenotyping(
       .getByLabel("details: activate to sort column ascending"),
   ).toBeVisible();
 
-  await page.getByRole("link", { name: "Request", exact: true }).click();
+  await page
+    .locator("#pheno_tabset")
+    .getByRole("link", { name: "Request", exact: true })
+    .click();
   await expect(page.getByRole("button", { name: "Yes, I do!" })).toBeEnabled();
   await page.getByRole("button", { name: "Yes, I do!" }).click();
   await expect(page.getByText("Process Pheno request: Done")).toBeVisible({
@@ -416,10 +440,16 @@ async function requestGenotyping(
     .getByRole("textbox", { name: "Browse..." })
     .setInputFiles("./tests/requestExamples/" + reqFile);
 
-  await page.getByRole("link", { name: "Check" }).click();
+  await page
+    .locator("#geno_tabset")
+    .getByRole("link", { name: "Check" })
+    .click();
   await expect(page.locator("#GenoUploaded")).toContainText("GOOD");
 
-  await page.getByRole("link", { name: "Summary" }).click();
+  await page
+    .locator("#geno_tabset")
+    .getByRole("link", { name: "Summary" })
+    .click();
   await expect(
     page.locator("#GenoInvoice").getByRole("cell", { name: "Task" }),
   ).toBeVisible();
@@ -433,7 +463,10 @@ async function requestGenotyping(
     page.locator("#GenoInvoice").locator("th").filter({ hasText: "Total" }),
   ).toBeVisible();
 
-  await page.getByRole("link", { name: "Data" }).click();
+  await page
+    .locator("#geno_tabset")
+    .getByRole("link", { name: "Data" })
+    .click();
   await expect(
     page
       .locator("#qryGeno")
@@ -450,7 +483,10 @@ async function requestGenotyping(
       .getByLabel("details: activate to sort column ascending"),
   ).toBeVisible();
 
-  await page.getByRole("link", { name: "Request", exact: true }).click();
+  await page
+    .locator("#geno_tabset")
+    .getByRole("link", { name: "Request", exact: true })
+    .click();
   await expect(page.getByRole("button", { name: "Yes, I do!" })).toBeEnabled();
   await page.getByRole("button", { name: "Yes, I do!" }).click();
   await expect(page.getByText("Process Geno request: Done")).toBeVisible({

--- a/ui.R
+++ b/ui.R
@@ -59,6 +59,10 @@ shinyUI(
           tabName = "geno",
           icon = icon("dna")
         ),
+        menuItem("Data Visualisation",
+          tabName = "data-viz",
+          icon = icon("chart-line")
+        ),
         menuItem("Evaluation",
           tabName = "eval",
           icon = icon("medal")
@@ -158,6 +162,14 @@ shinyUI(
         #   local = TRUE,
         #   encoding = "UTF-8"
         # )$value,
+
+        # ---- Evaluation ----
+        tabItem(
+          tabName = "data-viz",
+          fluidRow(
+            uiOutput("data_viz_UI")
+          )
+        ),
 
         # ---- Evaluation ----
         tabItem(

--- a/www/style.css
+++ b/www/style.css
@@ -126,3 +126,7 @@ details > summary {
 .has-error {
   color: #dd4b39;
 }
+
+.warning {
+  color: #ff5733;
+}


### PR DESCRIPTION
I added a new menu "Data visualisation".

For now this is a generic data-viz feature that can plot the data of a file uploaded by the user.

I pushed a working example on docker hub `juliendiot/plantbreedgame:development`.

The expected file format is the same as the phenotype data the user can download (ie. `tsv` file)

This can be used to visualized for example the phenotypes data from the app directly, but also any other data the user can generate (eg. BLUPs, predictions...)

The type of plots is automatically determined by the nature of the selected variables on X and Y axis:

- 1 variable:  Histogram / Bar plot
- 2 quantitative variables: Scatter plot (eg. the image below)
- 1 quantitative variable and 1 categorical variable: box plot
- 2 categorical variable: not implemented

Below the plot there is a data-table. Currently there is no "selection/highlight" feature that link the selected element of the table and the plot. I may think about implementing that if requested.

There is a screenshot example (for 2 quantitative variables `trait1` and `trait2` colored by `year`):

![image](https://github.com/user-attachments/assets/2e4690a1-1bb0-41b4-8cef-198d13c9eda6)


Currently, **only players with the "tester" status can access it** to keep "the gameplay" unchanged. @timflutre Let me know if you think I should rather make it available to all players.

> Since I am planning on adding new feature to make the game easier, I may have to work on another system for managing the game's features' permissions. Instead of having different player "status" it would be more "feature access" oriented. When we create a new player, we select which feature it can have access to. 


cc. @chabrault





